### PR TITLE
깃허브 로그인 관련 에러 수정

### DIFF
--- a/frontend/src/api/article.ts
+++ b/frontend/src/api/article.ts
@@ -6,7 +6,7 @@ export const postWritingArticle = (article: {
 	category: string;
 }) => {
 	const accessToken = localStorage.getItem('accessToken');
-	return axios.post('/api/articles', {
+	return axios.post('http://192.168.0.155:8080/api/articles', {
 		header: {
 			'Access-Control-Allow-Origin': '*',
 			Authorization: `Bearer ${accessToken}`,

--- a/frontend/src/api/login.ts
+++ b/frontend/src/api/login.ts
@@ -11,11 +11,12 @@ export const getGithubURL = async () => {
 };
 
 export const postLogin = (code: string) =>
-	axios.post<{ accesstoken: string }>('http://192.168.0.155:8080/api/auth/token', {
-		headers: {
-			'Access-Control-Allow-Origin': '*',
+	axios.post<{ accesstoken: string }>(
+		'http://192.168.0.155:8080/api/auth/token',
+		{ code },
+		{
+			headers: {
+				'Access-Control-Allow-Origin': '*',
+			},
 		},
-		body: {
-			code,
-		},
-	});
+	);

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -18,16 +18,14 @@ const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 const queryClient = new QueryClient();
 
 root.render(
-	<React.StrictMode>
-		<ThemeProvider theme={theme}>
-			<Global styles={reset} />
-			<QueryClientProvider client={queryClient}>
-				<RecoilRoot>
-					<BrowserRouter>
-						<App />
-					</BrowserRouter>
-				</RecoilRoot>
-			</QueryClientProvider>
-		</ThemeProvider>
-	</React.StrictMode>,
+	<ThemeProvider theme={theme}>
+		<Global styles={reset} />
+		<QueryClientProvider client={queryClient}>
+			<RecoilRoot>
+				<BrowserRouter>
+					<App />
+				</BrowserRouter>
+			</RecoilRoot>
+		</QueryClientProvider>
+	</ThemeProvider>,
 );

--- a/frontend/src/mock/login.ts
+++ b/frontend/src/mock/login.ts
@@ -1,7 +1,5 @@
 import { rest } from 'msw';
 
 export const LoginHandler = [
-	rest.get('/api/auth/github', (req, res, ctx) => {
-		return res(ctx.status(200));
-	}),
+	rest.get('http://192.168.0.155:8080/api/auth/github', (req, res, ctx) => res(ctx.status(200))),
 ];

--- a/frontend/src/pages/Login/index.tsx
+++ b/frontend/src/pages/Login/index.tsx
@@ -2,6 +2,7 @@ import { getGithubURL } from '@/api/login';
 import PageLayout from '@/components/layout/PageLayout/PageLayout';
 import { mobileTitleSecondary } from '@/constants/titleType';
 import styled from '@emotion/styled';
+import { useEffect, useState } from 'react';
 import { useQuery } from 'react-query';
 import LoginButton from './LoginButton/LoginButton';
 
@@ -21,15 +22,20 @@ const Login = () => {
 			enabled: false,
 		},
 	);
+	const [pageLoading, setPageLoading] = useState(false);
 
 	const handleLoginButtonClick = () => {
 		refetch();
-		if (isSuccess) {
-			window.location.href = data;
-		}
 	};
 
-	if (isLoading) return <div>로딩중...</div>;
+	useEffect(() => {
+		if (isSuccess) {
+			setPageLoading(true);
+			window.location.href = data;
+		}
+	}, [isSuccess]);
+
+	if (isLoading || pageLoading) return <div>로딩중...</div>;
 
 	if (isError) {
 		if (error instanceof Error) {


### PR DESCRIPTION
#39 

## 기능명세

로그인 버튼이 2번눌러야 요청이 되는 문제해결

## 에러 원인 

side effect 코드가 event handler안에 있어서 발생하는 에러. useEffect내로 로직을 제거 해주니까 해결할수 있었다.

## 추가적인 에러

깃헙 페이지로 이동할때 로딩중이 깜빡였다가 로그인 페이지로 돌아온후 잠시후에 깃헙 페이지로 이동하여 UX적 불편함이 있었음

## 해결방법

pageLoading이라는 상태를 만들어서 success될때 바로 pageLoading이 될수 있도록 코드 추가 