### PR TITLE
로그인 여부에 따라 유저의 접근 페이지 제한 

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,8 @@ import WritingArticles from '@/pages/WritingArticles';
 import CategorySelector from '@/pages/CategorySelector/CategorySelector';
 import LoginController from './pages/Login/LoginController/LoginController';
 import Home from './pages/Home';
+import PrivateRouter from './components/router/PrivateRouter';
+import PublicRouter from './components/router/PublicRouter';
 
 const Layout = styled.div`
 	position: relative;
@@ -19,20 +21,28 @@ const Content = styled.main`
 	padding-bottom: 7rem;
 `;
 
-const App = () => (
-	<Layout>
-		<Header />
-		<Content>
-			<Routes>
-				<Route path="/callback" element={<LoginController />} />
-				<Route path="/category" element={<CategorySelector />} />
-				<Route path="/article/:category" element={<WritingArticles />} />
-				<Route path="/login" element={<Login />} />
-				<Route path="/" element={<Home />} />
-			</Routes>
-		</Content>
-		<TabBar />
-	</Layout>
-);
+const App = () => {
+	const isLogin = !!localStorage.getItem('accessToken');
+
+	return (
+		<Layout>
+			<Header />
+			<Content>
+				<Routes>
+					<Route path="/callback" element={<LoginController />} />
+					<Route path="/category" element={<CategorySelector />} />
+					<Route element={<PrivateRouter isAuthenticated={isLogin} />}>
+						<Route path="/article/:category" element={<WritingArticles />} />
+					</Route>
+					<Route element={<PublicRouter isAuthenticated={isLogin} />}>
+						<Route path="/login" element={<Login />} />
+					</Route>
+					<Route path="/" element={<Home />} />
+				</Routes>
+			</Content>
+			<TabBar />
+		</Layout>
+	);
+};
 
 export default App;

--- a/frontend/src/components/router/PrivateRouter.tsx
+++ b/frontend/src/components/router/PrivateRouter.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+
+const PrivateRouter = ({ isAuthenticated }: { isAuthenticated: boolean }) => {
+	useEffect(() => {
+		if (!isAuthenticated) {
+			alert('로그인 후 이용해주세요');
+		}
+	}, [isAuthenticated]);
+
+	return isAuthenticated ? <Outlet /> : <Navigate to="/login" replace />;
+};
+
+export default PrivateRouter;

--- a/frontend/src/components/router/PublicRouter.tsx
+++ b/frontend/src/components/router/PublicRouter.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+
+const PublicRouter = ({ isAuthenticated }: { isAuthenticated: boolean }) => {
+	useEffect(() => {
+		if (isAuthenticated) {
+			alert('로그인 상태에서 이용할수 없는 서비스입니다.');
+		}
+	}, []);
+
+	return isAuthenticated ? <Navigate to="/" replace /> : <Outlet />;
+};
+
+export default PublicRouter;


### PR DESCRIPTION
#47 

## 기능 명세

```jsx
const PublicRouter = ({ isAuthenticated }: { isAuthenticated: boolean }) => {
	useEffect(() => {
		if (isAuthenticated) {
			alert('로그인 상태에서 이용할수 없는 서비스입니다.');
		}
	}, []);

	return isAuthenticated ? <Navigate to="/" replace /> : <Outlet />;
};
```

```jsx

const PrivateRouter = ({ isAuthenticated }: { isAuthenticated: boolean }) => {
	useEffect(() => {
		if (!isAuthenticated) {
			alert('로그인 후 이용해주세요');
		}
	}, [isAuthenticated]);

	return isAuthenticated ? <Outlet /> : <Navigate to="/login" replace />;
};
```

react router v6의 중첩 라우팅 기능을 이용하여 publicRouter, privateRouter를 구현하여 선언적으로 접근 제한을 구현