### PR TITLE
AuthService 테스트 추가 및 패키지 분리

### DIFF
--- a/backend/src/docs/asciidoc/article.adoc
+++ b/backend/src/docs/asciidoc/article.adoc
@@ -16,10 +16,10 @@ endif::[]
 
 `POST /api/articles`
 
-요청 HTTP
+=== Request
 
 include::{snippets}/article-create/http-request.adoc[]
 
-성공 응답 HTTP
+=== Response
 
 include::{snippets}/article-create/http-response.adoc[]

--- a/backend/src/main/java/com/woowacourse/gongseek/auth/application/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/auth/application/AuthService.java
@@ -16,9 +16,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class AuthService {
 
-    private final GithubOAuthClient githubOAuthClient;
+    private final OAuthClient githubOAuthClient;
     private final MemberRepository memberRepository;
-    private final JwtTokenProvider jwtTokenProvider;
+    private final TokenProvider jwtTokenProvider;
 
     public OAuthLoginUrlResponse getLoginUrl() {
         return new OAuthLoginUrlResponse(githubOAuthClient.getRedirectUrl());

--- a/backend/src/main/java/com/woowacourse/gongseek/auth/application/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/auth/application/AuthService.java
@@ -1,5 +1,7 @@
 package com.woowacourse.gongseek.auth.application;
 
+import com.woowacourse.gongseek.auth.infra.GithubOAuthClient;
+import com.woowacourse.gongseek.auth.infra.JwtTokenProvider;
 import com.woowacourse.gongseek.auth.presentation.dto.OAuthCodeRequest;
 import com.woowacourse.gongseek.auth.presentation.dto.OAuthLoginUrlResponse;
 import com.woowacourse.gongseek.auth.presentation.dto.TokenResponse;

--- a/backend/src/main/java/com/woowacourse/gongseek/auth/application/OAuthClient.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/auth/application/OAuthClient.java
@@ -1,0 +1,10 @@
+package com.woowacourse.gongseek.auth.application;
+
+import com.woowacourse.gongseek.auth.presentation.dto.GithubProfileResponse;
+
+public interface OAuthClient {
+
+    String getRedirectUrl();
+
+    GithubProfileResponse getMemberProfile(String code);
+}

--- a/backend/src/main/java/com/woowacourse/gongseek/auth/application/TokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/auth/application/TokenProvider.java
@@ -1,0 +1,10 @@
+package com.woowacourse.gongseek.auth.application;
+
+public interface TokenProvider {
+
+    String createToken(String payload);
+
+    String getPayload(String token);
+
+    boolean validateToken(String token);
+}

--- a/backend/src/main/java/com/woowacourse/gongseek/auth/infra/GithubOAuthClient.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/auth/infra/GithubOAuthClient.java
@@ -1,4 +1,4 @@
-package com.woowacourse.gongseek.auth.application;
+package com.woowacourse.gongseek.auth.infra;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.gongseek.auth.presentation.dto.GithubAccessTokenRequest;

--- a/backend/src/main/java/com/woowacourse/gongseek/auth/infra/GithubOAuthClient.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/auth/infra/GithubOAuthClient.java
@@ -1,6 +1,7 @@
 package com.woowacourse.gongseek.auth.infra;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.gongseek.auth.application.OAuthClient;
 import com.woowacourse.gongseek.auth.presentation.dto.GithubAccessTokenRequest;
 import com.woowacourse.gongseek.auth.presentation.dto.GithubAccessTokenResponse;
 import com.woowacourse.gongseek.auth.presentation.dto.GithubProfileResponse;
@@ -16,7 +17,7 @@ import org.springframework.web.client.RestTemplate;
 
 @Getter
 @Component
-public class GithubOAuthClient {
+public class GithubOAuthClient implements OAuthClient {
 
     private static final String BASE_URL = "https://github.com";
     private static final String REDIRECT_URL = "http://localhost:8080/callback";
@@ -42,10 +43,12 @@ public class GithubOAuthClient {
         this.restTemplate = restTemplate;
     }
 
+    @Override
     public String getRedirectUrl() {
         return String.format(BASE_URL + LOGIN_URL_SUFFIX, clientId, REDIRECT_URL);
     }
 
+    @Override
     public GithubProfileResponse getMemberProfile(String code) {
         GithubAccessTokenResponse accessTokenResponse = getGithubAccessToken(code);
         return getGithubProfile(accessTokenResponse);

--- a/backend/src/main/java/com/woowacourse/gongseek/auth/infra/JwtTokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/auth/infra/JwtTokenProvider.java
@@ -1,4 +1,4 @@
-package com.woowacourse.gongseek.auth.application;
+package com.woowacourse.gongseek.auth.infra;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;

--- a/backend/src/main/java/com/woowacourse/gongseek/auth/infra/JwtTokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/auth/infra/JwtTokenProvider.java
@@ -1,5 +1,6 @@
 package com.woowacourse.gongseek.auth.infra;
 
+import com.woowacourse.gongseek.auth.application.TokenProvider;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
@@ -13,7 +14,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
-public class JwtTokenProvider {
+public class JwtTokenProvider implements TokenProvider {
 
     private final long validityInMilliseconds;
     private final Key secretKey;
@@ -24,6 +25,7 @@ public class JwtTokenProvider {
         this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
     }
 
+    @Override
     public String createToken(String payload) {
         Claims claims = Jwts.claims().setSubject(payload);
         Date now = new Date();
@@ -37,12 +39,14 @@ public class JwtTokenProvider {
                 .compact();
     }
 
+    @Override
     public String getPayload(String token) {
         return getClaimsJws(token)
                 .getBody()
                 .getSubject();
     }
 
+    @Override
     public boolean validateToken(String token) {
         try {
             Jws<Claims> claims = getClaimsJws(token);

--- a/backend/src/main/java/com/woowacourse/gongseek/auth/presentation/AuthenticationInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/auth/presentation/AuthenticationInterceptor.java
@@ -1,6 +1,6 @@
 package com.woowacourse.gongseek.auth.presentation;
 
-import com.woowacourse.gongseek.auth.application.JwtTokenProvider;
+import com.woowacourse.gongseek.auth.infra.JwtTokenProvider;
 import com.woowacourse.gongseek.auth.utils.TokenExtractor;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;

--- a/backend/src/main/java/com/woowacourse/gongseek/config/AuthenticationConfig.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/config/AuthenticationConfig.java
@@ -1,6 +1,6 @@
 package com.woowacourse.gongseek.config;
 
-import com.woowacourse.gongseek.auth.application.JwtTokenProvider;
+import com.woowacourse.gongseek.auth.infra.JwtTokenProvider;
 import com.woowacourse.gongseek.auth.presentation.AuthenticationArgumentResolver;
 import com.woowacourse.gongseek.auth.presentation.AuthenticationInterceptor;
 import java.util.List;

--- a/backend/src/test/java/com/woowacourse/gongseek/article/presentation/ArticleControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/article/presentation/ArticleControllerTest.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.gongseek.article.application.ArticleService;
 import com.woowacourse.gongseek.article.presentation.dto.ArticleIdResponse;
 import com.woowacourse.gongseek.article.presentation.dto.ArticleRequest;
-import com.woowacourse.gongseek.auth.application.JwtTokenProvider;
+import com.woowacourse.gongseek.auth.infra.JwtTokenProvider;
 import com.woowacourse.gongseek.config.RestDocsConfig;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;

--- a/backend/src/test/java/com/woowacourse/gongseek/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/auth/application/AuthServiceTest.java
@@ -17,8 +17,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
 @SuppressWarnings("NonAsciiCharacters")
+@Transactional
 @SpringBootTest
 class AuthServiceTest {
 
@@ -29,7 +29,7 @@ class AuthServiceTest {
     private MemberRepository memberRepository;
 
     @MockBean
-    private GithubOAuthClient githubOAuthClient;
+    private OAuthClient githubOAuthClient;
 
     @Test
     void 리다이렉트_URL_을_반환한다() {

--- a/backend/src/test/java/com/woowacourse/gongseek/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/auth/application/AuthServiceTest.java
@@ -1,10 +1,10 @@
 package com.woowacourse.gongseek.auth.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
-import com.woowacourse.gongseek.auth.infra.GithubOAuthClient;
 import com.woowacourse.gongseek.auth.presentation.dto.GithubProfileResponse;
 import com.woowacourse.gongseek.auth.presentation.dto.OAuthCodeRequest;
 import com.woowacourse.gongseek.auth.presentation.dto.OAuthLoginUrlResponse;
@@ -57,7 +57,10 @@ class AuthServiceTest {
 
         TokenResponse response = authService.generateAccessToken(new OAuthCodeRequest("code"));
 
-        assertThat(member.getAvatarUrl()).isEqualTo("example@xxx");
-        assertThat(response).isNotNull();
+        assertAll(
+                () -> assertThat(member.getAvatarUrl()).isEqualTo("example@xxx"),
+                () -> assertThat(response).isNotNull()
+        );
+
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongseek/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/auth/application/AuthServiceTest.java
@@ -1,12 +1,23 @@
 package com.woowacourse.gongseek.auth.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
+import com.woowacourse.gongseek.auth.infra.GithubOAuthClient;
+import com.woowacourse.gongseek.auth.presentation.dto.GithubProfileResponse;
+import com.woowacourse.gongseek.auth.presentation.dto.OAuthCodeRequest;
 import com.woowacourse.gongseek.auth.presentation.dto.OAuthLoginUrlResponse;
+import com.woowacourse.gongseek.auth.presentation.dto.TokenResponse;
+import com.woowacourse.gongseek.member.domain.Member;
+import com.woowacourse.gongseek.member.domain.repository.MemberRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 @SuppressWarnings("NonAsciiCharacters")
 @SpringBootTest
 class AuthServiceTest {
@@ -14,10 +25,39 @@ class AuthServiceTest {
     @Autowired
     private AuthService authService;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @MockBean
+    private GithubOAuthClient githubOAuthClient;
+
     @Test
     void 리다이렉트_URL_을_반환한다() {
         OAuthLoginUrlResponse oAuthUrl = authService.getLoginUrl();
 
         assertThat(oAuthUrl).isNotNull();
+    }
+
+    @Test
+    void 엑세스토큰을_발급한다() {
+        given(githubOAuthClient.getMemberProfile(any()))
+                .willReturn(new GithubProfileResponse("1", "giron", "example@xxx"));
+
+        TokenResponse response = authService.generateAccessToken(new OAuthCodeRequest("code"));
+
+        assertThat(response).isNotNull();
+    }
+
+    @Test
+    void 기존_유저의_정보가_바뀌면_로그인을_했을때_업데이트되고_엑세스토큰을_발급한다() {
+        Member member = new Member("giron", "gyuchool", "qwesad@qwe");
+        memberRepository.save(member);
+        given(githubOAuthClient.getMemberProfile(any()))
+                .willReturn(new GithubProfileResponse("gyuchool", "giron", "example@xxx"));
+
+        TokenResponse response = authService.generateAccessToken(new OAuthCodeRequest("code"));
+
+        assertThat(member.getAvatarUrl()).isEqualTo("example@xxx");
+        assertThat(response).isNotNull();
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongseek/auth/infra/JwtTokenProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/auth/infra/JwtTokenProviderTest.java
@@ -1,7 +1,8 @@
-package com.woowacourse.gongseek.auth.application;
+package com.woowacourse.gongseek.auth.infra;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.woowacourse.gongseek.auth.infra.JwtTokenProvider;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -9,6 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("NonAsciiCharacters")
 class JwtTokenProviderTest {
 
     private static final Long EXPIRE_TIME = 86400000L;

--- a/backend/src/test/java/com/woowacourse/gongseek/auth/infra/JwtTokenProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/auth/infra/JwtTokenProviderTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.gongseek.auth.infra;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.woowacourse.gongseek.auth.application.TokenProvider;
 import com.woowacourse.gongseek.auth.infra.JwtTokenProvider;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -16,7 +17,7 @@ class JwtTokenProviderTest {
     private static final Long EXPIRE_TIME = 86400000L;
     private static final String SECRET_KEY = "thisIsTestSecretKey-thisIsTestSecretKey-thisIsTestSecretKey";
 
-    private final JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(EXPIRE_TIME, SECRET_KEY);
+    private final TokenProvider jwtTokenProvider = new JwtTokenProvider(EXPIRE_TIME, SECRET_KEY);
 
     @Test
     void 토큰을_생성한다() {

--- a/backend/src/test/java/com/woowacourse/gongseek/auth/utils/TokenExtractorTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/auth/utils/TokenExtractorTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.woowacourse.gongseek.auth.application.JwtTokenProvider;
+import com.woowacourse.gongseek.auth.infra.JwtTokenProvider;
 import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;


### PR DESCRIPTION
## 한 일
 - 외부 api를 사용하는 OAuthClient가 도메인과 관련있는 패키지(`application`)에 있어서 나중에 외부 api관련 버그가 발생하거나 변경이 가해질 때, infra패키지에서만 처리하도록 하려고 패키지 분리했습니다. 추후 인터페이스를 분리하는 방향으로 가야할 것 같습니다.
 
 - OAuthClient를 테스트하려면 깃허브 서버와의 통신을 테스트해야 한다고 생각했고 그러려면 깃허브 서버를 Fake로 만드는 방향을 생각했습니다. 하지만 이부분은 구현이 어렵다고 판단되어 우선 OAuthClient를 모킹하여 AuthService만 테스트했습니다.

Close #64 