### PR TITLE
webpack build 에러 수정

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,7 @@
 	},
 	"scripts": {
 		"start": "webpack serve --open --config webpack/webpack.common.js",
-		"build": "webpack --mode production",
+		"build": "webpack --mode production --config webpack/webpack.common.js",
 		"storybook": "start-storybook -p 6006",
 		"build-storybook": "build-storybook",
 		"test": "jest"

--- a/frontend/webpack/webpack.common.js
+++ b/frontend/webpack/webpack.common.js
@@ -5,7 +5,7 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 module.exports = {
 	entry: './src/index.tsx',
 	output: {
-		path: path.join(__dirname, '/dist'),
+		path: path.join(__dirname, '../dist'),
 		filename: '[name].bundle.js',
 		publicPath: '/',
 	},


### PR DESCRIPTION
#136 

## 기능 명세

build를 하는 script 명령어에 webpack파일의 경로를 주지않아서 발생한 에러였다. 

추가적으로 output의 경로가 /dist가 되어있어서 webpack폴더내에 생기던것을 ../dist 로 수정하여서 해결하였다.