### PR TITLE
2글자 이하로 검색하면 경고창 보여주기

### DIFF
--- a/frontend/src/components/common/SearchBar/SearchBar.tsx
+++ b/frontend/src/components/common/SearchBar/SearchBar.tsx
@@ -2,17 +2,24 @@ import { useState } from 'react';
 import { useRecoilState } from 'recoil';
 
 import * as S from '@/components/common/SearchBar/SearchBar.styles';
+import useSnackBar from '@/hooks/useSnackBar';
 import { searchState } from '@/store/searchState';
+import { validatedSearchInput } from '@/utils/validateInput';
 
 const SearchBar = ({ isValid }: { isValid: boolean }) => {
 	const [searchInput, setSearchInput] = useState('');
 	const [searchInputState, setSearchInputState] = useRecoilState(searchState);
+	const { showSnackBar } = useSnackBar();
 
 	const onChangeInputValue = (e: { target: HTMLInputElement }) => {
 		setSearchInput(e.target.value);
 	};
 
 	const onSubmitSearchTarget = () => {
+		if (!validatedSearchInput(searchInput)) {
+			showSnackBar('검색어는 최소 2글자 이상이여야 합니다!');
+			return;
+		}
 		setSearchInputState({
 			isSearching: true,
 			target: searchInput,


### PR DESCRIPTION
Close #237 

기존에 잘못된 검색어를 입력하여도, 유저에게 안내매세지를 보여주지 않는 문제 상황이 있어서 

2글자 미만으로 검색어를 입력하였을 때에, 유저에게 스낵바로 이를 알린다