### PR TITLE
데스크탑 화면에서의 대응

### DIFF
--- a/frontend/src/components/layout/Header/Header.tsx
+++ b/frontend/src/components/layout/Header/Header.tsx
@@ -10,6 +10,13 @@ import { getUserIsLogin } from '@/store/userState';
 const Header = () => {
 	const isLogin = useRecoilValue(getUserIsLogin);
 	const { isSearchOpen } = useRecoilValue(searchState);
+
+	const onLogOutClick = () => {
+		window.confirm('정말로 로그아웃을 하시겠습니까?');
+		localStorage.removeItem('accessToken');
+		window.location.href = '/';
+	};
+
 	if (isSearchOpen) {
 		return (
 			<S.Container>
@@ -42,7 +49,7 @@ const Header = () => {
 				{isLogin ? (
 					<>
 						<S.NavBarItem to="/my-page">마이페이지</S.NavBarItem>
-						<S.LogOutItem>로그아웃</S.LogOutItem>
+						<S.LogOutItem onClick={onLogOutClick}>로그아웃</S.LogOutItem>
 					</>
 				) : (
 					<S.NavBarItem to="/login">로그인</S.NavBarItem>

--- a/frontend/src/components/layout/Header/Header.tsx
+++ b/frontend/src/components/layout/Header/Header.tsx
@@ -12,9 +12,11 @@ const Header = () => {
 	const { isSearchOpen } = useRecoilValue(searchState);
 
 	const onLogOutClick = () => {
-		window.confirm('정말로 로그아웃을 하시겠습니까?');
-		localStorage.removeItem('accessToken');
-		window.location.href = '/';
+		if (window.confirm('정말로 로그아웃을 하시겠습니까?')) {
+			localStorage.removeItem('accessToken');
+			window.location.href = '/';
+			return;
+		}
 	};
 
 	if (isSearchOpen) {

--- a/frontend/src/components/layout/Header/Header.tsx
+++ b/frontend/src/components/layout/Header/Header.tsx
@@ -41,7 +41,7 @@ const Header = () => {
 			<S.NavBar>
 				{isLogin ? (
 					<>
-						<S.NavBarItem to="">마이페이지</S.NavBarItem>
+						<S.NavBarItem to="/my-page">마이페이지</S.NavBarItem>
 						<S.LogOutItem>로그아웃</S.LogOutItem>
 					</>
 				) : (

--- a/frontend/src/pages/CategoryArticles/CategoryArticles.styles.tsx
+++ b/frontend/src/pages/CategoryArticles/CategoryArticles.styles.tsx
@@ -28,7 +28,8 @@ export const ArticleItemList = styled.div`
 
 	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
 		display: grid;
-		grid-template-columns: 1fr 1fr 1fr 1fr;
+		width: 100%;
+		grid-template-columns: 1fr 1fr 1fr;
 		place-items: center;
 		margin: 0 auto;
 		gap: ${({ theme }) => theme.size.SIZE_022};

--- a/frontend/src/pages/Home/ArticleItem/ArticleItem.styles.tsx
+++ b/frontend/src/pages/Home/ArticleItem/ArticleItem.styles.tsx
@@ -1,0 +1,80 @@
+import { FaRegCommentDots } from 'react-icons/fa';
+
+import styled from '@emotion/styled';
+
+export const ArticleContent = styled.div`
+	display: flex;
+
+	flex-direction: column;
+	justify-content: space-between;
+
+	width: 80%;
+	height: 100%;
+
+	border-radius: ${({ theme }) => theme.size.SIZE_010};
+
+	padding: ${({ theme }) => theme.size.SIZE_010};
+
+	z-index: ${({ theme }) => theme.zIndex.ARTICLE_POPULAR_CONTENT};
+`;
+
+export const Title = styled.h2`
+	width: 100%;
+	height: ${({ theme }) => theme.size.SIZE_040};
+
+	font-size: ${({ theme }) => theme.size.SIZE_014};
+	line-height: normal;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	overflow: hidden;
+
+	margin-top: ${({ theme }) => theme.size.SIZE_004};
+`;
+
+export const ArticleInfo = styled.div`
+	display: flex;
+
+	justify-content: space-between;
+`;
+
+export const ProfileBox = styled.div`
+	display: flex;
+
+	align-items: center;
+	gap: ${({ theme }) => theme.size.SIZE_006};
+`;
+
+export const UserImg = styled.img`
+	width: ${({ theme }) => theme.size.SIZE_024};
+	height: ${({ theme }) => theme.size.SIZE_024};
+
+	border-radius: 50%;
+
+	object-fit: cover;
+	object-position: center;
+`;
+
+export const UserName = styled.span`
+	font-size: ${({ theme }) => theme.size.SIZE_012};
+
+	color: ${({ theme }) => theme.colors.BLACK_600};
+`;
+
+export const CommentBox = styled.div`
+	display: flex;
+
+	align-items: center;
+	gap: ${({ theme }) => theme.size.SIZE_006};
+`;
+
+export const CommentCount = styled.span`
+	font-size: ${({ theme }) => theme.size.SIZE_012};
+
+	color: ${({ theme }) => theme.colors.BLACK_600};
+`;
+
+export const CommentIcon = styled(FaRegCommentDots)`
+	font-size: ${({ theme }) => theme.size.SIZE_016};
+
+	color: ${({ theme }) => theme.colors.BLACK_600};
+`;

--- a/frontend/src/pages/Home/ArticleItem/ArticleItem.tsx
+++ b/frontend/src/pages/Home/ArticleItem/ArticleItem.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import * as S from '@/pages/Home/ArticleItem/ArticleItem.styles';
 
 interface ArticleItemProps {
-	data: {
+	article: {
 		id: number;
 		title: string;
 		commentCount: number;
@@ -15,9 +15,9 @@ interface ArticleItemProps {
 	};
 }
 
-const ArticleItem = ({ data }: ArticleItemProps) => {
+const ArticleItem = ({ article }: ArticleItemProps) => {
 	const navigate = useNavigate();
-	const { id, title, author, commentCount, category } = data;
+	const { id, title, author, commentCount, category } = article;
 	return (
 		<>
 			<S.Title onClick={() => navigate(`/articles/${category}/${id}`)}>{title}</S.Title>

--- a/frontend/src/pages/Home/ArticleItem/ArticleItem.tsx
+++ b/frontend/src/pages/Home/ArticleItem/ArticleItem.tsx
@@ -1,0 +1,40 @@
+import { useNavigate } from 'react-router-dom';
+
+import * as S from '@/pages/Home/ArticleItem/ArticleItem.styles';
+
+interface ArticleItemProps {
+	data: {
+		id: number;
+		title: string;
+		commentCount: number;
+		category: string;
+		author: {
+			avatarUrl: string;
+			name: string;
+		};
+	};
+}
+
+const ArticleItem = ({ data }: ArticleItemProps) => {
+	const navigate = useNavigate();
+	const { id, title, author, commentCount, category } = data;
+	return (
+		<>
+			<S.Title onClick={() => navigate(`/articles/${category}/${id}`)}>{title}</S.Title>
+			<S.ArticleInfo>
+				<S.ProfileBox>
+					<S.UserImg alt="유저의 프로필 이미지가 보여지는 곳 입니다 " src={author.avatarUrl} />
+					<S.UserName>{author.name}</S.UserName>
+				</S.ProfileBox>
+				<S.CommentBox>
+					<S.CommentCount aria-label="댓글의 개수가 표시되는 곳입니다">
+						{commentCount}
+					</S.CommentCount>
+					<S.CommentIcon />
+				</S.CommentBox>
+			</S.ArticleInfo>
+		</>
+	);
+};
+
+export default ArticleItem;

--- a/frontend/src/pages/Home/PopularArticle/PopularArticle.styles.tsx
+++ b/frontend/src/pages/Home/PopularArticle/PopularArticle.styles.tsx
@@ -27,6 +27,8 @@ export const Container = styled.section`
 
 	width: 100%;
 	height: ${({ theme }) => theme.size.SIZE_080};
+
+	z-index: ${({ theme }) => theme.zIndex.POPULAR_ARTICLES};
 `;
 
 export const LeftBackgroundArticle = styled.div<{ colorKey: keyof typeof articleColors }>`

--- a/frontend/src/pages/Home/PopularArticle/PopularArticle.tsx
+++ b/frontend/src/pages/Home/PopularArticle/PopularArticle.tsx
@@ -1,9 +1,8 @@
 import Loading from '@/components/common/Loading/Loading';
-
-import { convertIdxToArticleColorKey } from '@/utils/converter';
-import useGetPopularArticles from '@/pages/Home/hooks/useGetPopularArticles';
-
+import ArticleItem from '@/pages/Home/ArticleItem/ArticleItem';
 import * as S from '@/pages/Home/PopularArticle/PopularArticle.styles';
+import useGetPopularArticles from '@/pages/Home/hooks/useGetPopularArticles';
+import { convertIdxToArticleColorKey } from '@/utils/converter';
 
 const PopularArticle = () => {
 	const {
@@ -13,7 +12,6 @@ const PopularArticle = () => {
 		currentIndex,
 		handleLeftSlideEvent,
 		handleRightSlideEvent,
-		navigateDetailPage,
 		mainArticleContent,
 	} = useGetPopularArticles();
 
@@ -36,22 +34,7 @@ const PopularArticle = () => {
 			<S.LeftArrowButton onClick={handleLeftSlideEvent} />
 			<S.LeftBackgroundArticle colorKey={getColorKey(currentIndex - 1)} />
 			<S.ArticleContent colorKey={getColorKey(currentIndex)} ref={mainArticleContent}>
-				<S.Title onClick={navigateDetailPage}>{data.articles[currentIndex].title}</S.Title>
-				<S.ArticleInfo>
-					<S.ProfileBox>
-						<S.UserImg
-							alt="유저의 프로필 이미지가 보여지는 곳 입니다 "
-							src={data?.articles[currentIndex].author.avatarUrl}
-						/>
-						<S.UserName>{data.articles[currentIndex].author.name}</S.UserName>
-					</S.ProfileBox>
-					<S.CommentBox>
-						<S.CommentCount aria-label="댓글의 개수가 표시되는 곳입니다">
-							{data.articles[currentIndex].commentCount}
-						</S.CommentCount>
-						<S.CommentIcon />
-					</S.CommentBox>
-				</S.ArticleInfo>
+				<ArticleItem article={data.articles[currentIndex]} />
 			</S.ArticleContent>
 			<S.RightBackgroundArticle colorKey={getColorKey(currentIndex + 1)} />
 			<S.RightArrowButton onClick={handleRightSlideEvent} />

--- a/frontend/src/pages/Home/hooks/useGetPopularArticles.tsx
+++ b/frontend/src/pages/Home/hooks/useGetPopularArticles.tsx
@@ -1,14 +1,12 @@
 import { AxiosError } from 'axios';
 import { useEffect, useRef, useState } from 'react';
 import { useQuery } from 'react-query';
-import { useNavigate } from 'react-router-dom';
 
 import { getPopularArticles, PopularArticles } from '@/api/article';
 import CustomError from '@/components/helper/CustomError';
 import * as S from '@/pages/Home/PopularArticle/PopularArticle.styles';
 
 const useGetPopularArticles = () => {
-	const navigate = useNavigate();
 	const [currentIndex, setCurrentIndex] = useState(0);
 	const [indexLimit, setIndexLimit] = useState(0);
 	const mainArticleContent = useRef<HTMLDivElement>(null);
@@ -49,14 +47,6 @@ const useGetPopularArticles = () => {
 		mainArticleContent.current?.animate(S.showPopularSlider, S.animationTiming);
 	};
 
-	const navigateDetailPage = () => {
-		if (isSuccess) {
-			navigate(
-				`/articles/${data.articles[currentIndex].category}/${data.articles[currentIndex].id}`,
-			);
-		}
-	};
-
 	return {
 		data,
 		isLoading,
@@ -65,7 +55,6 @@ const useGetPopularArticles = () => {
 		currentIndex,
 		handleLeftSlideEvent,
 		handleRightSlideEvent,
-		navigateDetailPage,
 		mainArticleContent,
 	};
 };

--- a/frontend/src/pages/Home/index.styles.tsx
+++ b/frontend/src/pages/Home/index.styles.tsx
@@ -66,8 +66,8 @@ export const ArticleItemList = styled.div`
 
 	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
 		display: grid;
-		width: 90%;
-		grid-template-columns: 1fr 1fr 1fr 1fr;
+		width: 100%;
+		grid-template-columns: 1fr 1fr 1fr;
 		place-items: center;
 		margin: 0 auto;
 		gap: ${({ theme }) => theme.size.SIZE_022};

--- a/frontend/src/pages/Search/SearchResult/SearchResult.styles.tsx
+++ b/frontend/src/pages/Search/SearchResult/SearchResult.styles.tsx
@@ -19,15 +19,14 @@ export const SearchResultBox = styled.div`
 	flex-direction: column;
 	width: 100%;
 
-
 	justify-content: center;
 	align-items: center;
 	gap: ${({ theme }) => theme.size.SIZE_020};
 
 	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
-		width: 90%;
+		width: 100%;
 		display: grid;
-		grid-template-columns: 1fr 1fr 1fr 1fr;
+		grid-template-columns: 1fr 1fr 1fr;
 		place-items: center;
 		margin: 0 auto;
 		gap: ${({ theme }) => theme.size.SIZE_022};

--- a/frontend/src/styles/Theme.ts
+++ b/frontend/src/styles/Theme.ts
@@ -86,6 +86,7 @@ const zIndex = {
 	ARTICLE_ARROW_BUTTON: 103,
 	MENU_SLIDER_BACKGROUND: 104,
 	MENU_SLIDER_CONTENT: 105,
+	POPULAR_ARTICLES: 1,
 };
 
 export const theme = {


### PR DESCRIPTION
Close #246 
- PopularArticle에서 큰 부분을 차지하는 Article을 표시하는 부분을 컴포넌트로 분리 
- Header에 z-index를 부여하여 Header에 겹쳐보이는 문제 해결 
- article이 4개로 보여질 때에 데스크탑 화면에서 벗어나 보이는 문제를 3개씩 보여주는 것으로 해결 