### PR TITLE
문의하기 페이지를 구현한다.

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import CategorySelector from '@/pages/CategorySelector/CategorySelector';
 import DiscussionDetail from '@/pages/DiscussionDetail';
 import ErrorDetail from '@/pages/ErrorDetail';
 import Home from '@/pages/Home';
+import InquirePage from '@/pages/Inquire';
 import Login from '@/pages/Login';
 import LoginController from '@/pages/Login/LoginController/LoginController';
 import MyPage from '@/pages/MyPage';
@@ -65,9 +66,9 @@ const App = () => {
 						<Route path="/articles/modify/:category/:id" element={<UpdateWriting />} />
 						<Route path="/search-result" element={<Search />} />
 						<Route path="/articles/discussion/:id" element={<DiscussionDetail />} />
-						<Route path="/articles/discussion/:id" element={<DiscussionDetail />} />
 						<Route path="/" element={<Home />} />
 						<Route path="/*" element={<NotFound />} />
+						<Route path="/inquire" element={<InquirePage />} />
 					</Routes>
 				</Content>
 			</ErrorBoundary>

--- a/frontend/src/components/common/MenuSlider/MenuSlider.tsx
+++ b/frontend/src/components/common/MenuSlider/MenuSlider.tsx
@@ -79,7 +79,14 @@ const MenuSlider = ({ closeSlider }: MenuSliderProps) => {
 					>
 						토론 카테고리
 					</S.LinkItem>
-					<S.LinkItem onClick={() => alert('준비중입니다..!')}>문의하기</S.LinkItem>
+					<S.LinkItem
+						onClick={() => {
+							navigate('/inquire');
+							closeSlider();
+						}}
+					>
+						문의하기
+					</S.LinkItem>
 				</S.LinkBox>
 			</S.MenuBox>
 		</S.Container>,

--- a/frontend/src/components/layout/Header/Header.tsx
+++ b/frontend/src/components/layout/Header/Header.tsx
@@ -60,7 +60,7 @@ const Header = () => {
 				<S.NavBarItem to="/category">글 쓰러 가기</S.NavBarItem>
 				<S.NavBarItem to="/articles/question">질문 카테고리</S.NavBarItem>
 				<S.NavBarItem to="/articles/discussion">토론 카테고리</S.NavBarItem>
-				<S.NavBarItem to="/">문의하기</S.NavBarItem>
+				<S.NavBarItem to="/inquire">문의하기</S.NavBarItem>
 			</S.NavBar>
 		</S.Container>
 	);

--- a/frontend/src/pages/Inquire/index.styles.tsx
+++ b/frontend/src/pages/Inquire/index.styles.tsx
@@ -1,0 +1,31 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+	display: flex;
+
+	justify-content: center;
+	align-items: center;
+
+	width: 100%;
+`;
+
+export const InquireButton = styled.button`
+	width: 100%;
+	max-width: ${({ theme }) => theme.size.SIZE_260};
+	height: fit-content;
+
+	border: none;
+	border-radius: ${({ theme }) => theme.size.SIZE_010};
+
+	color: white;
+	background-color: ${({ theme }) => theme.colors.PURPLE_500};
+
+	padding: ${({ theme }) => theme.size.SIZE_006};
+
+	cursor: pointer;
+
+	&:hover,
+	&active {
+		background-color: ${({ theme }) => theme.colors.PURPLE_400};
+	}
+`;

--- a/frontend/src/pages/Inquire/index.tsx
+++ b/frontend/src/pages/Inquire/index.tsx
@@ -1,0 +1,28 @@
+import PageLayout from '@/components/layout/PageLayout/PageLayout';
+import { mobileTitleSecondary } from '@/constants/titleType';
+import * as S from '@/pages/Inquire/index.styles';
+
+const InquirePage = () => {
+	const onClickInquireButton = () => {
+		window.location.href = 'https://github.com/woowacourse-teams/2022-gong-seek/issues';
+	};
+
+	return (
+		<S.Container>
+			<PageLayout
+				width="80%"
+				maxWidth="25rem"
+				height="18rem"
+				flexDirection="column"
+				justifyContent="space-around"
+				padding="1rem"
+			>
+				<h2 css={mobileTitleSecondary}>문의하기</h2>
+				<p>문의는 깃허브 이슈를 통해서 남겨주세요.</p>
+				<S.InquireButton onClick={onClickInquireButton}>문의하기</S.InquireButton>
+			</PageLayout>
+		</S.Container>
+	);
+};
+
+export default InquirePage;


### PR DESCRIPTION
close #271 

## 구현 사항
- 문의하기 페이지 UI 구현
- 문의하기 누를시 공식 깃헙 이슈로 이동할수 있도록 구현
- navbar, menuSilder에 문의하기 연결

## UI

### 데스크탑
<img width="1496" alt="스크린샷 2022-08-10 오후 2 58 39" src="https://user-images.githubusercontent.com/85891751/183826834-b5da876f-900c-4e62-9604-b5f95301e8ea.png">

### 모바일
<img width="345" alt="스크린샷 2022-08-10 오후 2 58 49" src="https://user-images.githubusercontent.com/85891751/183826835-0fadbafa-7ddd-4064-a025-18f7ca8571af.png">

로그인 페이지 UI와 유사하게 구현하였습니다.

