### PR TITLE
검색의 무한스크롤 기능 수정

### DIFF
--- a/frontend/src/api/search.ts
+++ b/frontend/src/api/search.ts
@@ -24,6 +24,7 @@ export const getSearchResult = async ({
 	return {
 		articles: data.articles,
 		hasNext: data.hasNext,
-		cursorId: '',
+		cursorId: String(data.articles[data.articles.length - 1].id),
+		target: target,
 	};
 };

--- a/frontend/src/pages/Search/hooks/useGetSearch.tsx
+++ b/frontend/src/pages/Search/hooks/useGetSearch.tsx
@@ -13,21 +13,30 @@ const useGetSearch = (target: string) => {
 		useInfiniteQuery<
 			InfiniteSearchResultType,
 			AxiosError<{ errorCode: keyof typeof ErrorMessage; message: string }>
-		>('search-result', () => getSearchResult({ target, cursorId }), {
-			getNextPageParam: (lastPage) => {
-				const { hasNext, articles } = lastPage;
+		>(
+			'search-result',
+			({
+				pageParam = {
+					target,
+					cursorId,
+				},
+			}) => getSearchResult(pageParam),
+			{
+				getNextPageParam: (lastPage) => {
+					const { hasNext, articles, cursorId, target } = lastPage;
 
-				if (hasNext && articles.length >= 1) {
-					const lastCursorId = articles[articles.length - 1].id;
-					return {
-						articles,
-						hasNext,
-						lastCursorId,
-					};
-				}
-				return undefined;
+					if (hasNext) {
+						return {
+							articles,
+							hasNext,
+							cursorId,
+							target,
+						};
+					}
+					return;
+				},
 			},
-		});
+		);
 
 	useEffect(() => {
 		if (isError) {

--- a/frontend/src/types/searchResponse.ts
+++ b/frontend/src/types/searchResponse.ts
@@ -7,4 +7,5 @@ export interface SearchResultType {
 
 export interface InfiniteSearchResultType extends SearchResultType {
 	cursorId: string;
+	target: string;
 }


### PR DESCRIPTION
Close #207 

검색 무한 스크롤 기능 수정 
기존에 다음 페이지 값으로 넘어가지 않고 있었음 
인피니트 스크롤에서는 pageParam을 활용해서 값을 다음으로 넘겨야함 