### PR TITLE
로그 설정 파일을 읽지 못하는 버그 해결

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongseek/GongseekApplication.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/GongseekApplication.java
@@ -9,5 +9,4 @@ public class GongseekApplication {
     public static void main(String[] args) {
         SpringApplication.run(GongseekApplication.class, args);
     }
-
 }

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -13,17 +13,17 @@
     <property name="MAX_HISTORY" value="14"/>
 
     <springProfile name="local">
-        <include resource="console-appender.xml"/>
+        <include resource="logging/console-appender.xml"/>
         <root level="info">
             <appender-ref ref="CONSOLE"/>
         </root>
     </springProfile>
 
     <springProfile name="prod">
-        <include resource="console-appender.xml"/>
-        <include resource="file-info-appender.xml"/>
-        <include resource="file-warn-appender.xml"/>
-        <include resource="file-error-appender.xml"/>
+        <include resource="logging/console-appender.xml"/>
+        <include resource="logging/file-info-appender.xml"/>
+        <include resource="logging/file-warn-appender.xml"/>
+        <include resource="logging/file-error-appender.xml"/>
         <root level="info">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="FILE-INFO"/>
@@ -33,11 +33,11 @@
     </springProfile>
 
     <springProfile name="dev">
-        <include resource="console-appender.xml"/>
-        <include resource="file-debug-appender.xml"/>
-        <include resource="file-info-appender.xml"/>
-        <include resource="file-warn-appender.xml"/>
-        <include resource="file-error-appender.xml"/>
+        <include resource="logging/console-appender.xml"/>
+        <include resource="logging/file-debug-appender.xml"/>
+        <include resource="logging/file-info-appender.xml"/>
+        <include resource="logging/file-warn-appender.xml"/>
+        <include resource="logging/file-error-appender.xml"/>
         <root level="debug">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="FILE-DEBUG"/>


### PR DESCRIPTION
- logback-spring.xml 파일을 resources 하위로 위치시키고, include 경로를 변경해줬습니다.

Close #289 