### PR TITLE
변경된 좋아요 api 명세에 맞춰서 코드 수정

### DIFF
--- a/frontend/src/components/common/ArticleContent/ArticleContent.tsx
+++ b/frontend/src/components/common/ArticleContent/ArticleContent.tsx
@@ -25,7 +25,11 @@ const ArticleContent = ({ category, article, author, articleId }: ArticleContent
 		postIsLoading,
 		isLike,
 		likeCount,
-	} = useHeartClick(String(article.id));
+	} = useHeartClick({
+		prevIsLike: article.isLike,
+		prevLikeCount: article.likeCount,
+		articleId,
+	});
 	const { isLoading, handleDeleteArticle } = useDeleteArticleContent();
 	const navigate = useNavigate();
 

--- a/frontend/src/components/common/ArticleItem/ArticleItem.tsx
+++ b/frontend/src/components/common/ArticleItem/ArticleItem.tsx
@@ -28,7 +28,11 @@ const ArticleItem = ({ article, onClick }: ArticleItemProps) => {
 		postIsLoading,
 		isLike,
 		likeCount,
-	} = useHeartClick(String(article.id));
+	} = useHeartClick({
+		prevIsLike: article.isLike,
+		prevLikeCount: article.likeCount,
+		articleId: String(article.id),
+	});
 
 	if (deleteIsLoading || postIsLoading) {
 		return <Loading />;

--- a/frontend/src/hooks/useHeartClick.tsx
+++ b/frontend/src/hooks/useHeartClick.tsx
@@ -1,4 +1,4 @@
-import { AxiosError } from 'axios';
+import { AxiosError, AxiosResponse } from 'axios';
 import { useEffect, useState } from 'react';
 import { useMutation } from 'react-query';
 
@@ -23,14 +23,14 @@ const useHeartClick = ({
 		isError: postIsError,
 		error: postError,
 		isSuccess: postIsSuccess,
-	} = useMutation<unknown, AxiosError, string>(`like${articleId}`, postAddLikeArticle);
+	} = useMutation<AxiosResponse, AxiosError, string>(`like${articleId}`, postAddLikeArticle);
 	const {
 		mutate: deleteMutate,
 		isLoading: deleteIsLoading,
 		isError: deleteIsError,
 		error: deleteError,
 		isSuccess: deleteIsSuccess,
-	} = useMutation<unknown, AxiosError, string>(`unlike${articleId}`, deleteLikeArticle);
+	} = useMutation<AxiosResponse, AxiosError, string>(`unlike${articleId}`, deleteLikeArticle);
 
 	useEffect(() => {
 		if (postIsError) {

--- a/frontend/src/hooks/useHeartClick.tsx
+++ b/frontend/src/hooks/useHeartClick.tsx
@@ -1,33 +1,36 @@
-import { AxiosError, AxiosResponse } from 'axios';
-import { useEffect } from 'react';
+import { AxiosError } from 'axios';
+import { useEffect, useState } from 'react';
 import { useMutation } from 'react-query';
 
 import { deleteLikeArticle, postAddLikeArticle } from '@/api/like';
 import { queryClient } from '@/index';
 
-const useHeartClick = (articleId: string) => {
+const useHeartClick = ({
+	prevIsLike,
+	prevLikeCount,
+	articleId,
+}: {
+	prevIsLike: boolean;
+	prevLikeCount: number;
+	articleId: string;
+}) => {
+	const [isLike, setIsLike] = useState(prevIsLike);
+	const [likeCount, setLikeCount] = useState(prevLikeCount);
+
 	const {
-		data: postData,
 		mutate: postMutate,
 		isLoading: postIsLoading,
 		isError: postIsError,
 		error: postError,
 		isSuccess: postIsSuccess,
-	} = useMutation<AxiosResponse<{ isLike: boolean; likeCount: number }>, AxiosError, string>(
-		`like${articleId}`,
-		postAddLikeArticle,
-	);
+	} = useMutation<unknown, AxiosError, string>(`like${articleId}`, postAddLikeArticle);
 	const {
-		data: deleteData,
 		mutate: deleteMutate,
 		isLoading: deleteIsLoading,
 		isError: deleteIsError,
 		error: deleteError,
 		isSuccess: deleteIsSuccess,
-	} = useMutation<AxiosResponse<{ isLike: boolean; likeCount: number }>, AxiosError, string>(
-		`unlike${articleId}`,
-		deleteLikeArticle,
-	);
+	} = useMutation<unknown, AxiosError, string>(`unlike${articleId}`, deleteLikeArticle);
 
 	useEffect(() => {
 		if (postIsError) {
@@ -46,10 +49,14 @@ const useHeartClick = (articleId: string) => {
 	});
 
 	const onLikeButtonClick = () => {
+		setIsLike(true);
+		setLikeCount((prevLikeCount) => prevLikeCount + 1);
 		postMutate(articleId);
 	};
 
 	const onUnlikeButtonClick = () => {
+		setIsLike(false);
+		setLikeCount((prevLikeCount) => prevLikeCount - 1);
 		deleteMutate(articleId);
 	};
 
@@ -58,8 +65,8 @@ const useHeartClick = (articleId: string) => {
 		deleteIsLoading,
 		onLikeButtonClick,
 		onUnlikeButtonClick,
-		isLike: postData?.data.isLike || deleteData?.data.isLike,
-		likeCount: postData?.data.likeCount || deleteData?.data.likeCount,
+		isLike,
+		likeCount,
 	};
 };
 


### PR DESCRIPTION
## 구현사항
- 백엔드에서 좋아요, 좋아요 취소를 했을떄 isLike와 likeCount를 리턴해줄 경우 성능이 좋지 않다고 하여 isLike와 likeCount는 state로 관리하고 다시 게시물을 불러올때 get요청으로 최신 isLike와 likeCount를 받을수 있도록 수정