### PR TITLE
해시태그 관련 에러를 수정한다

### DIFF
--- a/frontend/src/components/common/ArticleItem/ArticleItem.tsx
+++ b/frontend/src/components/common/ArticleItem/ArticleItem.tsx
@@ -64,7 +64,8 @@ const ArticleItem = ({ article, onClick }: ArticleItemProps) => {
 				</S.RightFooterBox>
 			</S.FooterBox>
 			<S.HashTagListBox>
-				{article.hashTag.length >= 1 &&
+				{article.hashTag &&
+					article.hashTag.length >= 1 &&
 					article.hashTag.map((item) => <S.HashTagItem key={item}>#{item}</S.HashTagItem>)}
 			</S.HashTagListBox>
 		</S.Container>


### PR DESCRIPTION
해시태그가 없는 게시글들과 관련하여 에러가 발생함 

해당 게시글들에 대해서 해시태그가 존재할 때에만 보여주도록 조건 추가함 