### PR TITLE
로그인 관련 에러를 수정한다

### DIFF
--- a/frontend/src/api/login.ts
+++ b/frontend/src/api/login.ts
@@ -19,7 +19,6 @@ export const postLogin = (code: string) =>
 		{
 			headers: {
 				'Access-Control-Allow-Origin': '*',
-				'Access-Control-Allow-Credentials': true,
 			},
 			withCredentials: true,
 		},

--- a/frontend/src/components/helper/ErrorBoundary.tsx
+++ b/frontend/src/components/helper/ErrorBoundary.tsx
@@ -25,10 +25,10 @@ class ErrorBoundary extends Component<Props, State> {
 
 	componentDidUpdate(_, prevState: State) {
 		if (prevState.error !== this.state.error) {
-			if (this.state.error && this.state.error.errorCode === 1005) {
+			if (this.state.error && Number(this.state.error.errorCode) === 1005) {
 				window.location.href = '/check-login';
 			}
-			if (this.state.error && this.state.error.errorCode === 1008) {
+			if (this.state.error && Number(this.state.error.errorCode) === 1008) {
 				alert('다시 로그인 해주세요');
 				deleteRefreshCookie();
 				window.location.href = '/login';

--- a/frontend/src/pages/Login/RefreshTokenHandler/RefreshTokenHandler.tsx
+++ b/frontend/src/pages/Login/RefreshTokenHandler/RefreshTokenHandler.tsx
@@ -1,11 +1,11 @@
 import { AxiosError } from 'axios';
+import { useEffect } from 'react';
 import { useQuery } from 'react-query';
 
 import { getAccessTokenByRefreshToken } from '@/api/login';
 import CustomError from '@/components/helper/CustomError';
 import { ErrorMessage } from '@/constants/ErrorMessage';
 import useSnackBar from '@/hooks/useSnackBar';
-import { useEffect } from '@storybook/addons';
 
 const RefreshTokenHandler = () => {
 	const { data, isSuccess, isError, error } = useQuery<


### PR DESCRIPTION
Close #322 

리프레시 토큰을 재발급 받는 곳에서 사용되는 useEffect가 storybook에서 import가 이루어지고 있었음 

에러 바운더리에서 vscode상 errorCode가 숫자값으로 추정되어 숫자로써 값을 비교했지만, response응답값은 문자열이라서
해당 에러가 분기문에서 걸리지 않아 처리를 해줌 