### PR TITLE
잘못된 URL 접근에 대한 NotFound페이지 띄우기 

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -63,14 +63,14 @@ const App = () => {
 						<Route element={<PublicRouter isAuthenticated={isLogin} />}>
 							<Route path="/login" element={<Login />} />
 						</Route>
-						<Route path="/articles/question/:id" element={<ErrorDetail />} />
 						<Route path="/articles/:category" element={<CategoryArticles />} />
+						<Route path="/articles/question/:id" element={<ErrorDetail />} />
+						<Route path="/articles/discussion/:id" element={<DiscussionDetail />} />
 						<Route path="/articles/modify/:category/:id" element={<UpdateWriting />} />
 						<Route path="/search-result" element={<Search />} />
-						<Route path="/articles/discussion/:id" element={<DiscussionDetail />} />
-						<Route path="/" element={<Home />} />
-						<Route path="/*" element={<NotFound />} />
 						<Route path="/inquire" element={<InquirePage />} />
+						<Route path="/*" element={<NotFound />} />
+						<Route path="/" element={<Home />} />
 					</Routes>
 				</Content>
 			</ErrorBoundary>

--- a/frontend/src/pages/CategoryArticles/CategoryArticles.tsx
+++ b/frontend/src/pages/CategoryArticles/CategoryArticles.tsx
@@ -16,6 +16,10 @@ const CategoryArticles = () => {
 		throw new Error('카테고리를 찾을 수 없습니다');
 	}
 
+	if (category !== 'discussion' && category !== 'question') {
+		navigate('/*');
+	}
+
 	const { data, fetchNextPage, sortIndex, setSortIndex, isLoading } =
 		useGetCategoryArticles(category);
 


### PR DESCRIPTION
카테고리 접근하는 url이 articles/:category
여서 다른 값들이 입력되어도 카테고리 조회 페이지로 이동하여 api 통신을 진행하고 있었음 

그래서 이를 방지 하기 위하여 CategoryArticles에서 searchParam이 개설된 카테고리 네임이 아닐 경우 NotFound페이지로 이동시킴