### PR TITLE
댓글을 수정할 때에 원본 글과 함께 수정할 수 있도록 한다

### DIFF
--- a/frontend/src/components/common/CommentInputModal/CommentInputModal.tsx
+++ b/frontend/src/components/common/CommentInputModal/CommentInputModal.tsx
@@ -34,7 +34,7 @@ const CommentInputModal = ({
 	placeholder,
 }: CommentInputModalProps) => {
 	const commentModal = document.getElementById('comment-portal');
-	const [comment, setComment] = useState('');
+	const [comment, setComment] = useState(placeholder);
 	const [isAnonymous, setIsAnonymous] = useState(false);
 
 	const {
@@ -78,7 +78,6 @@ const CommentInputModal = ({
 				aria-label="댓글을 입력해주세요"
 				value={comment}
 				onChange={(e) => setComment(e.target.value)}
-				placeholder={placeholder}
 			></S.CommentContent>
 			<S.SubmitBox>
 				<AnonymouseCheckBox setIsAnonymous={setIsAnonymous} />


### PR DESCRIPTION
Close #368 

댓글 수정할 때에 placeholder를 없애고 
글의 상태 초기값을 기존의 값으로 변경 