### PR TITLE
메뉴슬라이더를 외부 창을 클릭해도 사라지게 한다

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { Routes, Route } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 
+import MenuSlider from '@/components/common/MenuSlider/MenuSlider';
 import SnackBar from '@/components/common/SnackBar/SnackBar';
 import ErrorBoundary from '@/components/helper/ErrorBoundary';
 import PrivateRouter from '@/components/helper/PrivateRouter';
@@ -23,6 +24,7 @@ import UpdateWriting from '@/pages/UpdateWriting';
 import VoteDeadlineGenerator from '@/pages/VoteDeadlineGenerator';
 import VoteGenerator from '@/pages/VoteGenerator';
 import WritingArticles from '@/pages/WritingArticles';
+import { menuSliderState } from '@/store/menuSliderState';
 import { getUserIsLogin } from '@/store/userState';
 import styled from '@emotion/styled';
 
@@ -44,8 +46,21 @@ const Content = styled.main`
 	}
 `;
 
+const Dimmer = styled.div`
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+
+	background-color: ${({ theme }) => theme.colors.GRAY_500};
+
+	z-index: ${({ theme }) => theme.zIndex.MENU_SLIDER_BACKGROUND};
+`;
+
 const App = () => {
 	const isLogin = useRecoilValue(getUserIsLogin);
+	const [sliderState, setSliderState] = useRecoilState(menuSliderState);
 	return (
 		<Layout>
 			<Header />
@@ -77,6 +92,8 @@ const App = () => {
 			</ErrorBoundary>
 			<TabBar />
 			<SnackBar />
+			{sliderState.isOpen && <Dimmer onClick={() => setSliderState({ isOpen: false })} />}
+			{sliderState.isOpen && <MenuSlider closeSlider={() => setSliderState({ isOpen: false })} />}
 		</Layout>
 	);
 };

--- a/frontend/src/components/common/MenuSlider/MenuSlider.styles.tsx
+++ b/frontend/src/components/common/MenuSlider/MenuSlider.styles.tsx
@@ -11,20 +11,6 @@ const showSlider = keyframes`
 	}
 `;
 
-export const Container = styled.section`
-	display: flex;
-	position: fixed;
-
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
-
-	background-color: ${({ theme }) => theme.colors.GRAY_500};
-
-	z-index: ${({ theme }) => theme.zIndex.MENU_SLIDER_BACKGROUND};
-`;
-
 export const MenuBox = styled.div`
 	display: flex;
 	position: fixed;

--- a/frontend/src/components/common/MenuSlider/MenuSlider.tsx
+++ b/frontend/src/components/common/MenuSlider/MenuSlider.tsx
@@ -27,69 +27,67 @@ const MenuSlider = ({ closeSlider }: MenuSliderProps) => {
 	}
 
 	return reactDom.createPortal(
-		<S.Container>
-			<S.MenuBox>
-				<S.Header>
-					<S.BackButtonBox onClick={closeSlider}>
-						<S.BackButton />
-					</S.BackButtonBox>
-				</S.Header>
-				<S.LinkBox>
-					{isLogin && (
-						<S.LinkItem
-							onClick={() => {
-								onLogoutClick();
-								closeSlider();
-							}}
-						>
-							로그 아웃
-						</S.LinkItem>
-					)}
-					{!isLogin && (
-						<S.LinkItem
-							onClick={() => {
-								navigate('/login');
-								closeSlider();
-							}}
-						>
-							로그인
-						</S.LinkItem>
-					)}
+		<S.MenuBox>
+			<S.Header>
+				<S.BackButtonBox onClick={closeSlider}>
+					<S.BackButton />
+				</S.BackButtonBox>
+			</S.Header>
+			<S.LinkBox>
+				{isLogin && (
 					<S.LinkItem
 						onClick={() => {
-							navigate('/category');
+							onLogoutClick();
 							closeSlider();
 						}}
 					>
-						글 쓰러 가기
+						로그 아웃
 					</S.LinkItem>
+				)}
+				{!isLogin && (
 					<S.LinkItem
 						onClick={() => {
-							navigate('/articles/question');
+							navigate('/login');
 							closeSlider();
 						}}
 					>
-						질문 카테고리
+						로그인
 					</S.LinkItem>
-					<S.LinkItem
-						onClick={() => {
-							navigate('/articles/discussion');
-							closeSlider();
-						}}
-					>
-						토론 카테고리
-					</S.LinkItem>
-					<S.LinkItem
-						onClick={() => {
-							navigate('/inquire');
-							closeSlider();
-						}}
-					>
-						문의하기
-					</S.LinkItem>
-				</S.LinkBox>
-			</S.MenuBox>
-		</S.Container>,
+				)}
+				<S.LinkItem
+					onClick={() => {
+						navigate('/category');
+						closeSlider();
+					}}
+				>
+					글 쓰러 가기
+				</S.LinkItem>
+				<S.LinkItem
+					onClick={() => {
+						navigate('/articles/question');
+						closeSlider();
+					}}
+				>
+					질문 카테고리
+				</S.LinkItem>
+				<S.LinkItem
+					onClick={() => {
+						navigate('/articles/discussion');
+						closeSlider();
+					}}
+				>
+					토론 카테고리
+				</S.LinkItem>
+				<S.LinkItem
+					onClick={() => {
+						navigate('/inquire');
+						closeSlider();
+					}}
+				>
+					문의하기
+				</S.LinkItem>
+			</S.LinkBox>
+		</S.MenuBox>,
 		menuSlider,
 	);
 };

--- a/frontend/src/components/layout/TabBar/TabBar.tsx
+++ b/frontend/src/components/layout/TabBar/TabBar.tsx
@@ -1,12 +1,12 @@
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 
-import MenuSlider from '@/components/common/MenuSlider/MenuSlider';
 import * as S from '@/components/layout/TabBar/TabBar.styles';
+import { menuSliderState } from '@/store/menuSliderState';
 
 const TabBar = () => {
 	const navigate = useNavigate();
-	const [isMenuSliderOpen, setIsMenuSliderOpen] = useState(false);
+	const [sliderState, setSliderState] = useRecoilState(menuSliderState);
 
 	return (
 		<>
@@ -23,11 +23,10 @@ const TabBar = () => {
 				/>
 				<S.MenuLink
 					onClick={() => {
-						setIsMenuSliderOpen(true);
+						setSliderState({ isOpen: true });
 					}}
 				/>
 			</S.Section>
-			{isMenuSliderOpen && <MenuSlider closeSlider={() => setIsMenuSliderOpen(false)} />}
 		</>
 	);
 };

--- a/frontend/src/store/menuSliderState.ts
+++ b/frontend/src/store/menuSliderState.ts
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+
+export const menuSliderState = atom({
+	key: 'menuSliderState',
+	default: {
+		isOpen: false,
+	},
+});


### PR DESCRIPTION
Close #370 

기존에 닫힘 버튼을 눌러야 MenuSlider가 닫혔던 것을 
MenuSlider의 호출 부분을 App으로 이동시키고 
Dimmer창을 만들어 
외부 창을 클릭해도 (회색부분) MenuSlider가 닫힐 수 있도록 조정 