### PR TITLE
데스크탑에서의 nav의 순서를 조정한다

### DIFF
--- a/frontend/src/components/layout/Header/Header.tsx
+++ b/frontend/src/components/layout/Header/Header.tsx
@@ -49,17 +49,14 @@ const Header = () => {
 			</S.HeaderSection>
 			<S.NavBar>
 				{isLogin ? (
-					<>
-						<S.NavBarItem to="/my-page">마이페이지</S.NavBarItem>
-						<S.LogOutItem onClick={onLogOutClick}>로그아웃</S.LogOutItem>
-					</>
+					<S.LogOutItem onClick={onLogOutClick}>로그아웃</S.LogOutItem>
 				) : (
 					<S.NavBarItem to="/login">로그인</S.NavBarItem>
 				)}
-
 				<S.NavBarItem to="/category">글 쓰러 가기</S.NavBarItem>
 				<S.NavBarItem to="/articles/question">질문 카테고리</S.NavBarItem>
 				<S.NavBarItem to="/articles/discussion">토론 카테고리</S.NavBarItem>
+				{isLogin && <S.NavBarItem to="/my-page">마이페이지</S.NavBarItem>}
 				<S.NavBarItem to="/inquire">문의하기</S.NavBarItem>
 			</S.NavBar>
 		</S.Container>


### PR DESCRIPTION
Close #381 
로그인 상태일 때의 nav 아이템 순서를 조정함 
로그인과 로그아웃은 같은 위치에 있는 것이 유저의 혼동을 줄일 수 있을 것 같아서 동일한 위치에 배치 
마이페이지의 위치 수정 
![스크린샷 2022-08-17 오후 12 18 02](https://user-images.githubusercontent.com/60773373/185027487-f84f51d3-24e7-4ad2-8c63-09e0a30c5d37.png)

