### PR TITLE
비동기 통신이 불필요하게 나가는 것을 방지한다

### DIFF
--- a/frontend/src/components/common/ArticleContent/hooks/useDeleteArticleContent.tsx
+++ b/frontend/src/components/common/ArticleContent/hooks/useDeleteArticleContent.tsx
@@ -14,7 +14,7 @@ const useDeleteArticleContent = () => {
 		unknown,
 		AxiosError<{ errorCode: keyof typeof ErrorMessage; message: string }>,
 		string
-	>(deleteArticle);
+	>(deleteArticle, { retry: 1 });
 	const navigate = useNavigate();
 
 	useEffect(() => {

--- a/frontend/src/components/common/Comment/hooks/useDeleteComment.tsx
+++ b/frontend/src/components/common/Comment/hooks/useDeleteComment.tsx
@@ -12,7 +12,7 @@ const useDeleteComment = () => {
 		unknown,
 		AxiosError<{ errorCode: keyof typeof ErrorMessage; message: string }>,
 		{ commentId: string }
-	>(deleteComments);
+	>(deleteComments, { retry: 1 });
 
 	const onDeleteButtonClick = (id: number) => {
 		if (confirm('정말로 삭제하시겠습니까?')) {

--- a/frontend/src/components/common/CommentInputModal/hooks/usePostCommentInputModal.tsx
+++ b/frontend/src/components/common/CommentInputModal/hooks/usePostCommentInputModal.tsx
@@ -14,7 +14,7 @@ const usePostCommentInputModal = (closeModal: CommentInputModalProps['closeModal
 		unknown,
 		AxiosError<{ errorCode: keyof typeof ErrorMessage; message: string }>,
 		{ content: string; id: string; isAnonymous: boolean }
-	>(postComments);
+	>(postComments, { retry: 1 });
 
 	useEffect(() => {
 		if (isError) {

--- a/frontend/src/components/common/CommentInputModal/hooks/usePutCommentInputModal.tsx
+++ b/frontend/src/components/common/CommentInputModal/hooks/usePutCommentInputModal.tsx
@@ -14,7 +14,7 @@ const usePutCommentInputModal = (closeModal: CommentInputModalProps['closeModal'
 		unknown,
 		AxiosError<{ errorCode: keyof typeof ErrorMessage; message: string }>,
 		{ content: string; commentId: string }
-	>(putComments);
+	>(putComments, { retry: 1 });
 
 	useEffect(() => {
 		if (isError) {

--- a/frontend/src/hooks/useGetDetailArticle.tsx
+++ b/frontend/src/hooks/useGetDetailArticle.tsx
@@ -13,7 +13,10 @@ const useGetDetailArticle = (id: string) => {
 	const { data, isError, isSuccess, isLoading, error, isIdle } = useQuery<
 		ArticleType,
 		AxiosError<{ errorCode: keyof typeof ErrorMessage; message: string }>
-	>(['detail-article', `article${id}`], () => getDetailArticle(id), { retry: false });
+	>(['detail-article', `article${id}`], () => getDetailArticle(id), {
+		retry: false,
+		refetchOnWindowFocus: false,
+	});
 	const setTempArticle = useSetRecoilState(articleState);
 
 	useEffect(() => {

--- a/frontend/src/hooks/useGetDetailComment.tsx
+++ b/frontend/src/hooks/useGetDetailComment.tsx
@@ -11,7 +11,7 @@ const useGetDetailComment = (id: string) => {
 	const { data, isError, isSuccess, isLoading, isIdle, error } = useQuery<
 		{ comments: CommentType[] },
 		AxiosError<{ errorCode: keyof typeof ErrorMessage; message: string }>
-	>('comments', () => getComments(id), { retry: false });
+	>('comments', () => getComments(id), { retry: false, refetchOnWindowFocus: false });
 
 	useEffect(() => {
 		if (isError) {

--- a/frontend/src/hooks/useHeartClick.tsx
+++ b/frontend/src/hooks/useHeartClick.tsx
@@ -21,14 +21,18 @@ const useHeartClick = ({
 		isError: postIsError,
 		error: postError,
 		isSuccess: postIsSuccess,
-	} = useMutation<AxiosResponse, AxiosError, string>(`like${articleId}`, postAddLikeArticle);
+	} = useMutation<AxiosResponse, AxiosError, string>(`like${articleId}`, postAddLikeArticle, {
+		retry: 1,
+	});
 	const {
 		mutate: deleteMutate,
 		isLoading: deleteIsLoading,
 		isError: deleteIsError,
 		error: deleteError,
 		isSuccess: deleteIsSuccess,
-	} = useMutation<AxiosResponse, AxiosError, string>(`unlike${articleId}`, deleteLikeArticle);
+	} = useMutation<AxiosResponse, AxiosError, string>(`unlike${articleId}`, deleteLikeArticle, {
+		retry: 1,
+	});
 
 	useEffect(() => {
 		setIsLike(prevIsLike);

--- a/frontend/src/pages/CategoryArticles/hooks/useGetCategoryArticles.tsx
+++ b/frontend/src/pages/CategoryArticles/hooks/useGetCategoryArticles.tsx
@@ -37,6 +37,7 @@ const useGetCategoryArticles = (category: string) => {
 				return;
 			},
 			retry: false,
+			refetchOnWindowFocus: false,
 		},
 	);
 

--- a/frontend/src/pages/Discussion/hooks/useGetVote.tsx
+++ b/frontend/src/pages/Discussion/hooks/useGetVote.tsx
@@ -10,7 +10,10 @@ const useVote = (articleId: string) => {
 	const { data, isLoading, isError, isSuccess, error } = useQuery<
 		TVote,
 		AxiosError<{ errorCode: keyof typeof ErrorMessage; message: string }>
-	>(['vote', `vote${articleId}`], () => getVoteItems(articleId), { retry: false });
+	>(['vote', `vote${articleId}`], () => getVoteItems(articleId), {
+		retry: false,
+		refetchOnWindowFocus: false,
+	});
 	const [totalCount, setTotalCount] = useState(0);
 	const [isEmptyVote, setIsEmptyVote] = useState(false);
 

--- a/frontend/src/pages/Home/hooks/useGetAllArticles.tsx
+++ b/frontend/src/pages/Home/hooks/useGetAllArticles.tsx
@@ -38,6 +38,7 @@ const useGetAllArticles = () => {
 				return;
 			},
 			retry: false,
+			refetchOnWindowFocus: false,
 		},
 	);
 

--- a/frontend/src/pages/Home/hooks/useGetPopularArticles.tsx
+++ b/frontend/src/pages/Home/hooks/useGetPopularArticles.tsx
@@ -15,7 +15,7 @@ const useGetPopularArticles = () => {
 	const { data, error, isSuccess, isError, isLoading, isIdle } = useQuery<
 		PopularArticles,
 		AxiosError<{ errorCode: keyof typeof ErrorMessage; message: string }>
-	>('popular-articles', getPopularArticles, { retry: false });
+	>('popular-articles', getPopularArticles, { retry: false, refetchOnWindowFocus: false });
 
 	useEffect(() => {
 		if (isSuccess) {

--- a/frontend/src/pages/MyPage/UserProfile/hooks/usePutUserProfile.tsx
+++ b/frontend/src/pages/MyPage/UserProfile/hooks/usePutUserProfile.tsx
@@ -11,7 +11,7 @@ const usePutUserProfile = () => {
 		AxiosResponse<{ name: string }>,
 		AxiosError<{ errorCode: keyof typeof ErrorMessage; message: string }>,
 		{ name: string }
-	>(editUserInfo);
+	>(editUserInfo, { retry: 1 });
 
 	useEffect(() => {
 		if (isError) {

--- a/frontend/src/pages/MyPage/hooks/useGetUserArticles.tsx
+++ b/frontend/src/pages/MyPage/hooks/useGetUserArticles.tsx
@@ -11,7 +11,7 @@ const useGetUserArticles = () => {
 	const { data, isSuccess, isLoading, isError, isIdle, error } = useQuery<
 		UserArticlesResponse,
 		AxiosError<{ errorCode: keyof typeof ErrorMessage; message: string }>
-	>('user-articles', getUserArticles, { retry: false });
+	>('user-articles', getUserArticles, { retry: 1, refetchOnWindowFocus: false });
 
 	useEffect(() => {
 		if (isError) {

--- a/frontend/src/pages/MyPage/hooks/useGetUserComments.tsx
+++ b/frontend/src/pages/MyPage/hooks/useGetUserComments.tsx
@@ -11,7 +11,7 @@ const useGetUserComments = () => {
 	const { data, isSuccess, isLoading, isIdle, isError, error } = useQuery<
 		UserCommentResponse,
 		AxiosError<{ errorCode: keyof typeof ErrorMessage; message: string }>
-	>('user-comments', getUserComments, { retry: false });
+	>('user-comments', getUserComments, { retry: 1, refetchOnWindowFocus: false });
 
 	useEffect(() => {
 		if (isError) {

--- a/frontend/src/pages/MyPage/hooks/useGetUserInfo.tsx
+++ b/frontend/src/pages/MyPage/hooks/useGetUserInfo.tsx
@@ -11,7 +11,7 @@ const useGetUserInfo = () => {
 	const { data, isSuccess, isError, isLoading, isIdle, error } = useQuery<
 		Author,
 		AxiosError<{ errorCode: keyof typeof ErrorMessage; message: string }>
-	>('user-info', getUserInfo, { retry: false });
+	>('user-info', getUserInfo, { retry: 1, refetchOnWindowFocus: false });
 
 	useEffect(() => {
 		if (isError) {

--- a/frontend/src/pages/Search/hooks/useGetSearch.tsx
+++ b/frontend/src/pages/Search/hooks/useGetSearch.tsx
@@ -36,6 +36,7 @@ const useGetSearch = (target: string) => {
 					return;
 				},
 				retry: 1,
+				refetchOnWindowFocus: false,
 			},
 		);
 

--- a/frontend/src/pages/UpdateWriting/hooks/usePostUpdateWritingArticle.tsx
+++ b/frontend/src/pages/UpdateWriting/hooks/usePostUpdateWritingArticle.tsx
@@ -23,7 +23,7 @@ const usePostUpdateWritingArticle = () => {
 		AxiosResponse<{ id: number; category: string }>,
 		AxiosError<{ errorCode: keyof typeof ErrorMessage; message: string }>,
 		{ title: string; content: string; id: string; tag: string[] }
-	>(putArticle);
+	>(putArticle, { retry: 1 });
 
 	useEffect(() => {
 		if (isSuccess) {

--- a/frontend/src/pages/WritingArticles/hooks/usePostWritingArticles.tsx
+++ b/frontend/src/pages/WritingArticles/hooks/usePostWritingArticles.tsx
@@ -21,7 +21,7 @@ const usePostWritingArticles = ({
 		AxiosResponse<{ id: string }>,
 		AxiosError<{ errorCode: keyof typeof ErrorMessage; message: string }>,
 		{ title: string; category: string; content: string; tag: string[]; isAnonymous: boolean }
-	>(postWritingArticle);
+	>(postWritingArticle, { retry: 1 });
 	const content = useRef<Editor | null>(null);
 	const [title, setTitle] = useState('');
 	const [categoryOption, setCategoryOption] = useState(category ? category : '');


### PR DESCRIPTION
close #383 

get 요청에 대해서는 window가 재포커스 되었을 때에, 비동기 통신 요청을 다시 보내지 않는다 

우선은 GET 요청들에 대해서 
refetchOnWindowFocus: false, 옵션을 주어서 비동기통신 요청을 다시 보내지 않게 한다 