### PR TITLE
마이페이지에서의 댓글을 보여줄 때에 게시글 정보도 같이 보여주기

### DIFF
--- a/frontend/src/pages/MyPage/UserArticleItem/UserArticleItem.styles.tsx
+++ b/frontend/src/pages/MyPage/UserArticleItem/UserArticleItem.styles.tsx
@@ -8,7 +8,7 @@ export const Container = styled.div`
 	flex-direction: column;
 
 	width: 90%;
-	height: ${({ theme }) => theme.size.SIZE_126};
+	height: fit-content;
 
 	border: ${({ theme }) => theme.size.SIZE_001} solid ${({ theme }) => theme.colors.GRAY_500};
 	border-radius: ${({ theme }) => theme.size.SIZE_004};
@@ -34,8 +34,13 @@ export const CategoryName = styled.div<{ isQuestion: boolean }>`
 	padding: ${({ theme }) => theme.size.SIZE_004};
 `;
 
+export const ArticleTitleBox = styled.div`
+	display: flex;
+	align-items: center;
+`;
+
 export const ArticleTitle = styled.div`
-	height: ${({ theme }) => theme.size.SIZE_050};
+	width: 80%;
 	font-size: ${({ theme }) => theme.size.SIZE_016};
 
 	overflow: hidden;
@@ -43,7 +48,7 @@ export const ArticleTitle = styled.div`
 	white-space: nowrap;
 	text-overflow: ellipsis;
 
-	padding: ${({ theme }) => theme.size.SIZE_002};
+	margin-left: ${({ theme }) => theme.size.SIZE_008};
 `;
 
 export const ArticleSubInfo = styled.div`

--- a/frontend/src/pages/MyPage/UserArticleItem/UserArticleItem.tsx
+++ b/frontend/src/pages/MyPage/UserArticleItem/UserArticleItem.tsx
@@ -16,8 +16,11 @@ const UserArticleItem = ({ article }: { article: UserArticleItemType }) => {
 				navigate(`/articles/${category}/${id}`);
 			}}
 		>
-			<S.CategoryName isQuestion={category === 'question'}>{한글_카테고리}</S.CategoryName>
-			<S.ArticleTitle>{title}</S.ArticleTitle>
+			<S.ArticleTitleBox>
+				<S.CategoryName isQuestion={category === 'question'}>{한글_카테고리}</S.CategoryName>
+				<S.ArticleTitle>{title}</S.ArticleTitle>
+			</S.ArticleTitleBox>
+
 			<S.ArticleSubInfo>
 				<S.ArticleTime>
 					{updatedAt.length !== 0 ? dateTimeConverter(updatedAt) : dateTimeConverter(createdAt)}

--- a/frontend/src/pages/MyPage/UserCommentBox/UserCommentBox.stories.tsx
+++ b/frontend/src/pages/MyPage/UserCommentBox/UserCommentBox.stories.tsx
@@ -16,14 +16,18 @@ export default {
 
 const Template: Story<{ comment: UserComment }> = (args) => <UserCommentBox {...args} />;
 
-export const DiscussionUserCommentBox = Template.bind({});
+export const UserCommentBoxTemplate = Template.bind({});
 
-DiscussionUserCommentBox.args = {
+UserCommentBoxTemplate.args = {
 	comment: {
 		id: 1,
 		content:
 			'마이페이지에서 보여지는 글 제목 글제목이 20자 이상이 넘어갈 경우 어떻게 처리할 것인지 보기 위한 예시 문장입니다',
 		createdAt: '2022-08-01T20:27',
 		updatedAt: '',
+		articleId: 1,
+		category: 'discussion',
+		articleTitle:
+			'제목 예시로 보여주는 부분 제목이 너무 길었을 때에 어떻게 보이는지 실험해보이기 위한 테스트 문장입니다',
 	},
 };

--- a/frontend/src/pages/MyPage/UserCommentBox/UserCommentBox.styles.tsx
+++ b/frontend/src/pages/MyPage/UserCommentBox/UserCommentBox.styles.tsx
@@ -18,6 +18,38 @@ export const Container = styled.div`
 	gap: ${({ theme }) => theme.size.SIZE_010};
 `;
 
+export const ArticleBox = styled.div`
+	display: flex;
+	align-items: center;
+`;
+
+export const ArticleTitle = styled.div`
+	width: 80%;
+	margin-left: ${({ theme }) => theme.size.SIZE_008};
+	overflow: hidden;
+	word-break: break-all;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+`;
+
+export const ArticleCategory = styled.div<{ isQuestion: boolean }>`
+	width: fit-content;
+	height: fit-content;
+
+	color: ${({ theme }) => theme.colors.WHITE};
+
+	border: ${({ theme }) => theme.size.SIZE_001} solid ${({ theme }) => theme.colors.GRAY_500};
+	border-radius: ${({ theme }) => theme.size.SIZE_010};
+
+	background-color: ${(props) => (props.isQuestion ? '#FF0063' : '#3AB0FF')};
+
+	padding: ${({ theme }) => theme.size.SIZE_004};
+`;
+
+export const ContentLabel = styled.span`
+	margin-right: ${({ theme }) => theme.size.SIZE_010};
+`;
+
 export const ContentBox = styled.div`
 	overflow: hidden;
 	word-break: break-all;

--- a/frontend/src/pages/MyPage/UserCommentBox/UserCommentBox.tsx
+++ b/frontend/src/pages/MyPage/UserCommentBox/UserCommentBox.tsx
@@ -5,12 +5,20 @@ import { UserComment } from '@/types/commentResponse';
 import { dateTimeConverter } from '@/utils/converter';
 
 const UserCommentBox = ({ comment }: { comment: UserComment }) => {
-	const { id, content, createdAt, updatedAt, articleId, category } = comment;
+	const { id, content, createdAt, updatedAt, articleId, category, articleTitle } = comment;
 	const navigate = useNavigate();
-
+	const 한글_카테고리 = category === 'question' ? '질문' : '토론';
 	return (
 		<S.Container onClick={() => navigate(`/articles/${category}/${articleId}`)}>
-			<S.ContentBox>{content}</S.ContentBox>
+			<S.ArticleBox>
+				<S.ArticleCategory isQuestion={category === 'question'}>{한글_카테고리}</S.ArticleCategory>
+				<S.ArticleTitle>{articleTitle}</S.ArticleTitle>
+			</S.ArticleBox>
+
+			<S.ContentBox>
+				<S.ContentLabel>댓글: </S.ContentLabel>
+				{content}
+			</S.ContentBox>
 			<S.CommentTime>
 				{updatedAt.length !== 0 ? dateTimeConverter(updatedAt) : dateTimeConverter(createdAt)}
 			</S.CommentTime>

--- a/frontend/src/pages/MyPage/UserItemBox/UserItemBox.tsx
+++ b/frontend/src/pages/MyPage/UserItemBox/UserItemBox.tsx
@@ -3,7 +3,7 @@ import { ReactNode, useState } from 'react';
 import * as S from '@/pages/MyPage/UserItemBox/UserItemBox.styles';
 
 const UserItemBox = ({ children, subTitle }: { children: ReactNode; subTitle: string }) => {
-	const [isContainerOpen, setIsContainerOpen] = useState(false);
+	const [isContainerOpen, setIsContainerOpen] = useState(true);
 
 	return (
 		<S.Container>

--- a/frontend/src/types/commentResponse.ts
+++ b/frontend/src/types/commentResponse.ts
@@ -14,6 +14,7 @@ export interface UserComment {
 	createdAt: string;
 	updatedAt: string;
 	articleId: number;
+	articleTitle: string;
 	category: string;
 }
 


### PR DESCRIPTION
Close #398 

- 마이페이지에서 댓글에 대해서 보여줄 때에 게시글의 제목도 같이 보여주기 
- 마이페이지에서의 게시글 보여주는 부분이 불필요하게 크다고 생각하여 height값 줄임 
- 마이페이지에서의 default값을 열어놓는 것으로 수정 

*현재 api 가 완성된 것이 아니라, ui상으로 확인 불가능 추후에 api 완성후 추가 수정 예정 