### PR TITLE
좋아요 순 정렬 안되는것 수정

### DIFF
--- a/frontend/src/api/article.ts
+++ b/frontend/src/api/article.ts
@@ -59,6 +59,28 @@ export const getAllArticle = async ({
 	sort,
 	cursorId,
 	cursorViews,
+	cursorLikes,
+}: {
+	category: string;
+	sort: '좋아요순' | '조회순' | '최신순';
+	cursorId: string;
+	cursorViews: string;
+	cursorLikes: string;
+}) => {
+	if (sort === '좋아요순') {
+		const data = await getAllArticlesByLikes({ category, cursorId, cursorLikes });
+		return data;
+	}
+
+	const data = getAllArticleByViewsOrLatest({ category, sort, cursorId, cursorViews });
+	return data;
+};
+
+export const getAllArticleByViewsOrLatest = async ({
+	category,
+	sort,
+	cursorId,
+	cursorViews,
 }: {
 	category: string;
 	sort: '좋아요순' | '조회순' | '최신순';
@@ -83,6 +105,35 @@ export const getAllArticle = async ({
 		hasNext: data.hasNext,
 		cursorId: String(data.articles[data.articles.length - 1]?.id),
 		cursorViews: String(data.articles[data.articles.length - 1]?.views),
+	};
+};
+
+export const getAllArticlesByLikes = async ({
+	category,
+	cursorId,
+	cursorLikes,
+}: {
+	category: string;
+	cursorId: string;
+	cursorLikes: string;
+}) => {
+	const accessToken = localStorage.getItem('accessToken');
+
+	const { data } = await axios.get<AllArticleResponse>(
+		`${HOME_URL}/api/articles/likes?category=${category}&cursorId=${cursorId}&cursorLikes=${cursorLikes}&size=6`,
+		{
+			headers: {
+				'Access-Control-Allow-Origin': '*',
+				Authorization: `Bearer ${accessToken}`,
+			},
+		},
+	);
+
+	return {
+		articles: data.articles,
+		hasNext: data.hasNext,
+		cursorId: String(data.articles[data.articles.length - 1]?.id),
+		cursorLikes: String(data.articles[data.articles.length - 1]?.likeCount),
 	};
 };
 

--- a/frontend/src/api/article.ts
+++ b/frontend/src/api/article.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 import { HOME_URL } from '@/constants/url';
-import { AllArticleResponse, ArticleType, CommonArticleType } from '@/types/articleResponse';
+import { AllArticleResponse, ArticleType } from '@/types/articleResponse';
 import { convertSort } from '@/utils/converter';
 
 export interface WritingArticles {
@@ -9,9 +9,6 @@ export interface WritingArticles {
 	content: string;
 	category: string;
 }
-
-type Category = 'question' | 'discussion' | 'total';
-type Sort = 'latest' | 'views';
 
 export const postWritingArticle = (article: WritingArticles) => {
 	const accessToken = localStorage.getItem('accessToken');
@@ -67,12 +64,14 @@ export const getAllArticle = async ({
 	cursorViews: string;
 	cursorLikes: string;
 }) => {
+	const accessToken = localStorage.getItem('accessToken');
+
 	if (sort === '좋아요순') {
-		const data = await getAllArticlesByLikes({ category, cursorId, cursorLikes });
+		const data = await getAllArticlesByLikes({ category, cursorId, cursorLikes, accessToken });
 		return data;
 	}
 
-	const data = getAllArticleByViewsOrLatest({ category, sort, cursorId, cursorViews });
+	const data = getAllArticleByViewsOrLatest({ category, sort, cursorId, cursorViews, accessToken });
 	return data;
 };
 
@@ -81,14 +80,15 @@ export const getAllArticleByViewsOrLatest = async ({
 	sort,
 	cursorId,
 	cursorViews,
+	accessToken,
 }: {
 	category: string;
 	sort: '좋아요순' | '조회순' | '최신순';
 	cursorId: string;
 	cursorViews: string;
+	accessToken: string | null;
 }) => {
 	const currentSort = convertSort(sort);
-	const accessToken = localStorage.getItem('accessToken');
 
 	const { data } = await axios.get<AllArticleResponse>(
 		`${HOME_URL}/api/articles?category=${category}&sort=${currentSort}&cursorId=${cursorId}&cursorViews=${cursorViews}&pageSize=6`,
@@ -112,13 +112,13 @@ export const getAllArticlesByLikes = async ({
 	category,
 	cursorId,
 	cursorLikes,
+	accessToken,
 }: {
 	category: string;
 	cursorId: string;
 	cursorLikes: string;
+	accessToken: string | null;
 }) => {
-	const accessToken = localStorage.getItem('accessToken');
-
 	const { data } = await axios.get<AllArticleResponse>(
 		`${HOME_URL}/api/articles/likes?category=${category}&cursorId=${cursorId}&cursorLikes=${cursorLikes}&size=6`,
 		{

--- a/frontend/src/pages/Home/hooks/useGetAllArticles.tsx
+++ b/frontend/src/pages/Home/hooks/useGetAllArticles.tsx
@@ -22,17 +22,19 @@ const useGetAllArticles = () => {
 				sort: sortIndex,
 				cursorId: '',
 				cursorViews: '',
+				cursorLikes: '',
 			},
 		}) => getAllArticle(pageParam),
 		{
 			getNextPageParam: (lastPage) => {
-				const { hasNext, cursorId, cursorViews } = lastPage;
+				const { hasNext, cursorId, cursorViews, cursorLikes } = lastPage;
 				if (hasNext) {
 					return {
 						category: currentCategory,
 						sort: sortIndex,
 						cursorId,
 						cursorViews,
+						cursorLikes,
 					};
 				}
 				return;

--- a/frontend/src/types/articleResponse.ts
+++ b/frontend/src/types/articleResponse.ts
@@ -29,6 +29,7 @@ export interface AllArticleResponse {
 export interface infiniteArticleResponse extends AllArticleResponse {
 	cursorId: string;
 	cursorViews?: string;
+	cursorLikes?: string;
 }
 
 export interface UserArticleItemType {


### PR DESCRIPTION
close #445 

## 수정사항
변경된 api에 맞춰 getAllArticles내에서 좋아요순일경우와 조회순, 최신순일 경우에 대하여 분기처리를 하여서 해결하였다.

