### PR TITLE
깃허브 이름이 없을 경우 로그인이 안되는 버그 해결

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongseek/auth/presentation/dto/GithubProfileResponse.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/auth/presentation/dto/GithubProfileResponse.java
@@ -31,5 +31,4 @@ public class GithubProfileResponse {
             name = githubId;
         }
     }
-
 }

--- a/backend/src/main/java/com/woowacourse/gongseek/auth/presentation/dto/GithubProfileResponse.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/auth/presentation/dto/GithubProfileResponse.java
@@ -2,7 +2,6 @@ package com.woowacourse.gongseek.auth.presentation.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.woowacourse.gongseek.member.domain.Member;
-import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -22,13 +21,6 @@ public class GithubProfileResponse {
     private String avatarUrl;
 
     public Member toMember() {
-        replaceEmptyNameWithGithubId();
         return new Member(name, githubId, avatarUrl);
-    }
-
-    private void replaceEmptyNameWithGithubId() {
-        if (Objects.isNull(name)) {
-            name = githubId;
-        }
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongseek/auth/presentation/dto/GithubProfileResponse.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/auth/presentation/dto/GithubProfileResponse.java
@@ -2,6 +2,7 @@ package com.woowacourse.gongseek.auth.presentation.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.woowacourse.gongseek.member.domain.Member;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -21,6 +22,14 @@ public class GithubProfileResponse {
     private String avatarUrl;
 
     public Member toMember() {
+        replaceEmptyNameWithGithubId();
         return new Member(name, githubId, avatarUrl);
     }
+
+    private void replaceEmptyNameWithGithubId() {
+        if (Objects.isNull(name)) {
+            name = githubId;
+        }
+    }
+
 }

--- a/backend/src/main/java/com/woowacourse/gongseek/auth/utils/CookieUtils.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/auth/utils/CookieUtils.java
@@ -13,7 +13,7 @@ public class CookieUtils {
                 .path("/")
                 .maxAge(MAX_AGE)
                 .secure(true)
-                .sameSite(SameSite.STRICT.attributeValue())
+                .sameSite(SameSite.NONE.attributeValue())
                 .build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongseek/member/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.woowacourse.gongseek.member.domain;
 
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -30,9 +31,17 @@ public class Member {
     private String avatarUrl;
 
     public Member(String name, String githubId, String avatarUrl) {
+        name = replaceEmptyNameWithGithubId(name, githubId);
         this.name = new Name(name);
         this.githubId = githubId;
         this.avatarUrl = avatarUrl;
+    }
+
+    private String replaceEmptyNameWithGithubId(String name, String githubId) {
+        if (Objects.isNull(name)) {
+            name = githubId;
+        }
+        return name;
     }
 
     public boolean isAnonymous(String cipherId) {

--- a/backend/src/test/java/com/woowacourse/gongseek/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/auth/application/AuthServiceTest.java
@@ -78,6 +78,18 @@ class AuthServiceTest {
     }
 
     @Test
+    void 유저의_이름이_null이면_깃허브_아이디로_대체된다() {
+        GithubProfileResponse profileResponse = new GithubProfileResponse(
+                주디.getGithubId(), null, 주디.getAvatarUrl());
+        given(githubOAuthClient.getMemberProfile(주디.getCode())).willReturn(profileResponse);
+
+        authService.generateToken(new OAuthCodeRequest(주디.getCode()));
+
+        Member actual = memberRepository.findByGithubId(주디.getGithubId()).get();
+        assertThat(actual.getName()).isEqualTo(주디.getGithubId());
+    }
+
+    @Test
     void 리프레시토큰이_유효하면_토큰을_재발급한다() {
         GithubProfileResponse profileResponse = new GithubProfileResponse(
                 기론.getGithubId(), 기론.getName(), 기론.getAvatarUrl());


### PR DESCRIPTION
## 버그
깃허브 이름이 없을 경우 로그인이 안되는 버그

## 해결 방법
깃허브 이름이 없을 경우 깃허브 아이디로 대체

## 이슈
Close #476 