### PR TITLE
게시물들이 가운데 정렬되도록 한다

### DIFF
--- a/frontend/src/pages/CategoryArticles/CategoryArticles.styles.tsx
+++ b/frontend/src/pages/CategoryArticles/CategoryArticles.styles.tsx
@@ -9,6 +9,10 @@ export const Container = styled.div`
 	width: 85%;
 
 	margin: ${({ theme }) => theme.size.SIZE_020} auto;
+
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+		width: 100%;
+	}
 `;
 
 export const CategoryArticlesTitle = styled.h2<{ category: string }>`


### PR DESCRIPTION
Close #442 

게시물들을 가운데로 정렬되도록 한다 

현재 질문, 토론 카테고리의 경우 부모의 width를 85%로 하여서 UI가 깨져보이는 것이였음 
모바일일 때에는 width 가 85프로여야 하기 때문에 media를 통해서 데스크탑 화면에서는 100%로 보이도록 조정 