### PR TITLE
리프레시토큰이 유효하지 않을 경우, 로그인 페이지로 이동한다

### DIFF
--- a/frontend/src/components/helper/ErrorBoundary.tsx
+++ b/frontend/src/components/helper/ErrorBoundary.tsx
@@ -2,7 +2,6 @@ import { Component } from 'react';
 
 import CustomError from '@/components/helper/CustomError';
 import { URL } from '@/constants/url';
-import { deleteRefreshCookie } from '@/utils/deleteRefreshCookie';
 
 type Props = {
 	fallback?: React.ReactNode;
@@ -34,7 +33,6 @@ class ErrorBoundary extends Component<Props, State> {
 			}
 			if (this.state.error && Number(this.state.error.errorCode) === 1008) {
 				alert('다시 로그인 해주세요');
-				deleteRefreshCookie();
 				window.location.href = URL.LOGIN;
 			}
 			if (this.state.error && Number(this.state.error.errorCode) === 3001) {

--- a/frontend/src/components/helper/ErrorBoundary.tsx
+++ b/frontend/src/components/helper/ErrorBoundary.tsx
@@ -24,25 +24,38 @@ class ErrorBoundary extends Component<Props, State> {
 	}
 
 	componentDidUpdate(_: never, prevState: State) {
-		if (prevState.error !== this.state.error) {
-			if (this.state.error && Number(this.state.error.errorCode) === 1004) {
-				window.location.href = URL.REFRESH_TOKEN_HANDLER;
-			}
-			if (this.state.error && Number(this.state.error.errorCode) === 1005) {
-				window.location.href = URL.REFRESH_TOKEN_HANDLER;
-			}
-			if (this.state.error && Number(this.state.error.errorCode) === 1008) {
+		if (prevState.error !== this.state.error && this.state.error) {
+			if (
+				Number(this.state.error.errorCode) === 1001 ||
+				Number(this.state.error.errorCode) === 1002 ||
+				Number(this.state.error.errorCode) === 1003 ||
+				Number(this.state.error.errorCode) === 1006 ||
+				Number(this.state.error.errorCode) === 1009 ||
+				Number(this.state.error.errorCode) === 2001
+			) {
 				alert('다시 로그인 해주세요');
 				window.location.href = URL.LOGIN;
+				return;
 			}
-			if (this.state.error && Number(this.state.error.errorCode) === 3001) {
-				window.location.href = '/*';
+			if (
+				Number(this.state.error.errorCode) === 1004 ||
+				Number(this.state.error.errorCode) === 1005
+			) {
+				window.location.href = URL.REFRESH_TOKEN_HANDLER;
+				return;
 			}
+			if (Number(this.state.error.errorCode) === 3001) {
+				window.location.href = URL.HOME;
+				return;
+			}
+			localStorage.removeItem('accessToken');
 		}
 
 		if (this.state.error !== null && prevState.error !== null) {
 			this.reset();
+			return;
 		}
+		window.location.href = URL.HOME;
 	}
 
 	static getDerivedStateFromError(error: Error) {

--- a/frontend/src/pages/Login/RefreshTokenHandler/RefreshTokenHandler.tsx
+++ b/frontend/src/pages/Login/RefreshTokenHandler/RefreshTokenHandler.tsx
@@ -17,10 +17,6 @@ const RefreshTokenHandler = () => {
 	const { showSnackBar } = useSnackBar();
 
 	useEffect(() => {
-		localStorage.removeItem('accessToken');
-	}, []);
-
-	useEffect(() => {
 		if (isError) {
 			if (!error.response) {
 				return;

--- a/frontend/src/utils/deleteRefreshCookie.ts
+++ b/frontend/src/utils/deleteRefreshCookie.ts
@@ -1,7 +1,0 @@
-export const deleteRefreshCookie = () => {
-	if (!document.cookie) {
-		return;
-	}
-	document.cookie = 'refreshToken=; expires=Thu, 01 Jan 1999 00:00:10 GMT;';
-	return;
-};


### PR DESCRIPTION
Close #516


- 유저 관련 인증에 대해서 에러 케이스를 모두 거친 후 로컬 상에 저장된 accessToken을 제거해야 에러가 더 이상 발생하지 않음 
*Home으로 이동하더라도 accessToken을 비워야 에러가 발생하지 않고 있다