### PR TITLE
RefreshToken의 바뀐 API 명세에 따라 수정을 진행한다

### DIFF
--- a/frontend/src/api/login.ts
+++ b/frontend/src/api/login.ts
@@ -25,10 +25,12 @@ export const postLogin = (code: string) =>
 	);
 
 export const getAccessTokenByRefreshToken = async () => {
+	const accessToken = localStorage.getItem('accessToken');
 	const response = await axios.get<{ accessToken: string }>(`${HOME_URL}/api/auth/refresh`, {
 		headers: {
 			'Access-Control-Allow-Origin': '*',
 			'Access-Control-Allow-Credentials': true,
+			Authorization: `Bearer ${accessToken}`,
 		},
 		withCredentials: true,
 	});


### PR DESCRIPTION
Close #530 

- refreshToken 으로 새로운  accessToken값을 요청할 때에 header에 accessToken 값도 같이 붙여서 보낸다 