### PR TITLE
리프레시토큰 에러를 수정한다

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,3 +1,4 @@
+import ErrorBoundary from './components/helper/ErrorBoundary';
 import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { BrowserRouter } from 'react-router-dom';
@@ -23,7 +24,9 @@ root.render(
 		<QueryClientProvider client={queryClient}>
 			<RecoilRoot>
 				<BrowserRouter>
-					<App />
+					<ErrorBoundary enable={false}>
+						<App />
+					</ErrorBoundary>
 				</BrowserRouter>
 			</RecoilRoot>
 		</QueryClientProvider>


### PR DESCRIPTION
close #546 

## 해결방법

현재 TabBar의 UserProfileIcon내에서 user정보를 받고오는데 현재 ErrorBoundary가 Content에만 감싸져있어서 Error를 감지하지 못하였다.
전역에 에러바운더리를 감싸서 해결해주었다.