### PR TITLE
투표 아이템 수가 잘못된 경우 예외코드를 수정한다

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongseek/vote/presentation/VoteController.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/vote/presentation/VoteController.java
@@ -29,7 +29,7 @@ public class VoteController {
     public ResponseEntity<VoteCreateResponse> create(
             @AuthenticationPrinciple AppMember appMember,
             @PathVariable Long articleId,
-            @RequestBody @Valid VoteCreateRequest voteCreateRequest
+            @Valid @RequestBody VoteCreateRequest voteCreateRequest
     ) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(voteService.create(appMember, articleId, voteCreateRequest));

--- a/backend/src/main/java/com/woowacourse/gongseek/vote/presentation/dto/VoteCreateRequest.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/vote/presentation/dto/VoteCreateRequest.java
@@ -3,7 +3,7 @@ package com.woowacourse.gongseek.vote.presentation.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import java.util.Set;
-import javax.validation.constraints.Size;
+import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class VoteCreateRequest {
 
-    @Size(max = 5, min = 2)
+    @NotNull
     private Set<String> items;
 
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")

--- a/backend/src/test/java/com/woowacourse/gongseek/acceptance/VoteAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/acceptance/VoteAcceptanceTest.java
@@ -19,6 +19,7 @@ import com.woowacourse.gongseek.vote.presentation.dto.VoteResponse;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -45,6 +46,38 @@ public class VoteAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
                 () -> assertThat(voteCreateResponse.getArticleId()).isEqualTo(articleId)
         );
+    }
+
+    @Test
+    void 투표_아이템_수가_올바르지_않은_경우_5009_예외_코드를_반환한다() {
+        AccessTokenResponse tokenResponse = 로그인을_한다(슬로);
+        Long articleId = 토론_게시글을_기명으로_등록한다(tokenResponse).getId();
+
+        ExtractableResponse<Response> response = 투표를_생성한다(
+                tokenResponse,
+                articleId,
+                new VoteCreateRequest(Set.of("DTO를 반환해야 한다."), LocalDateTime.now().plusDays(2))
+        );
+
+        ErrorResponse errorResponse = response.as(ErrorResponse.class);
+
+        assertThat(errorResponse.getErrorCode()).isEqualTo("5009");
+    }
+
+    @Test
+    void 투표_아이템_수가_null_경우_0001_예외_코드를_반환한다() {
+        AccessTokenResponse tokenResponse = 로그인을_한다(슬로);
+        Long articleId = 토론_게시글을_기명으로_등록한다(tokenResponse).getId();
+
+        ExtractableResponse<Response> response = 투표를_생성한다(
+                tokenResponse,
+                articleId,
+                new VoteCreateRequest(null, LocalDateTime.now().plusDays(2))
+        );
+
+        ErrorResponse errorResponse = response.as(ErrorResponse.class);
+
+        assertThat(errorResponse.getErrorCode()).isEqualTo("0001");
     }
 
     @Test


### PR DESCRIPTION
## 변경사항
- VoteCreateRequest 의 Size 어노테이션을 제거
- 제거한 이유
  - 해당 검증 로직은 도메인에 대한 검증라고 생각한다. 만약 Request에 검증 로직을 포함할 경우, 요구사항이 변할 때 도메인과  Request 모두 수정을 해줘야한다. 따라서 Request에 도메인 요구사항 검증을 제거한다.

### AS-IS
```java
@Size(max = 5, min = 2)
private Set<String> items;
```

### TO-BE
```java
@NotNull
private Set<String> items;
```

Close #560 