### PR TITLE
임시 게시글 저장 시 시간 생성되지 않는 문제 해결, 테스트를 위한 생성자 삭제

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongseek/article/domain/TempArticle.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/article/domain/TempArticle.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
@@ -22,8 +23,10 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter

--- a/backend/src/main/java/com/woowacourse/gongseek/article/domain/TempArticle.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/article/domain/TempArticle.java
@@ -62,20 +62,6 @@ public class TempArticle {
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
-    public TempArticle(String title, String content, String category, Member member, List<String> tempTags,
-                       boolean isAnonymous) {
-        this(
-                null,
-                new Title(title),
-                new Content(content),
-                Category.from(category),
-                member,
-                new TempTags(tempTags),
-                isAnonymous,
-                LocalDateTime.now()
-        );
-    }
-
     public void update(TempArticle tempArticle) {
         this.title = tempArticle.getTitle();
         this.content = tempArticle.getContent();

--- a/backend/src/main/java/com/woowacourse/gongseek/article/presentation/dto/TempArticleDetailResponse.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/article/presentation/dto/TempArticleDetailResponse.java
@@ -24,7 +24,7 @@ public class TempArticleDetailResponse {
 
     private String category;
 
-    private List<String> tags;
+    private List<String> tag;
 
     private Boolean isAnonymous;
 
@@ -37,7 +37,7 @@ public class TempArticleDetailResponse {
                 .title(tempArticle.getTitle().getValue())
                 .content(tempArticle.getContent().getValue())
                 .category(tempArticle.getCategory().getValue())
-                .tags(tempArticle.getTempTags())
+                .tag(tempArticle.getTempTags())
                 .isAnonymous(tempArticle.isAnonymous())
                 .createAt(tempArticle.getCreatedAt())
                 .build();

--- a/backend/src/test/java/com/woowacourse/gongseek/acceptance/TempArticleAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/acceptance/TempArticleAcceptanceTest.java
@@ -88,7 +88,7 @@ public class TempArticleAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(articleDetailResponse.getTitle()).isEqualTo("title"),
                 () -> assertThat(articleDetailResponse.getContent()).isEqualTo("content"),
                 () -> assertThat(articleDetailResponse.getCategory()).isEqualTo("discussion"),
-                () -> assertThat(articleDetailResponse.getTags().get(0)).isEqualTo("spring"),
+                () -> assertThat(articleDetailResponse.getTag().get(0)).isEqualTo("spring"),
                 () -> assertThat(articleDetailResponse.getIsAnonymous()).isFalse(),
                 () -> assertThat(articleDetailResponse.getCreateAt()).isNotNull()
         );

--- a/backend/src/test/java/com/woowacourse/gongseek/acceptance/TempArticleAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/acceptance/TempArticleAcceptanceTest.java
@@ -89,7 +89,8 @@ public class TempArticleAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(articleDetailResponse.getContent()).isEqualTo("content"),
                 () -> assertThat(articleDetailResponse.getCategory()).isEqualTo("discussion"),
                 () -> assertThat(articleDetailResponse.getTags().get(0)).isEqualTo("spring"),
-                () -> assertThat(articleDetailResponse.getIsAnonymous()).isFalse()
+                () -> assertThat(articleDetailResponse.getIsAnonymous()).isFalse(),
+                () -> assertThat(articleDetailResponse.getCreateAt()).isNotNull()
         );
     }
 

--- a/backend/src/test/java/com/woowacourse/gongseek/acceptance/VoteAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/acceptance/VoteAcceptanceTest.java
@@ -19,7 +19,6 @@ import com.woowacourse.gongseek.vote.presentation.dto.VoteResponse;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;

--- a/backend/src/test/java/com/woowacourse/gongseek/article/application/ArticleServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/article/application/ArticleServiceTest.java
@@ -6,7 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.gongseek.article.domain.Article;
 import com.woowacourse.gongseek.article.domain.Category;
+import com.woowacourse.gongseek.article.domain.Content;
 import com.woowacourse.gongseek.article.domain.TempArticle;
+import com.woowacourse.gongseek.article.domain.TempTags;
+import com.woowacourse.gongseek.article.domain.Title;
 import com.woowacourse.gongseek.article.domain.repository.ArticleRepository;
 import com.woowacourse.gongseek.article.domain.repository.TempArticleRepository;
 import com.woowacourse.gongseek.article.exception.ArticleNotFoundException;
@@ -766,8 +769,14 @@ public class ArticleServiceTest {
     @Transactional
     @Test
     void 게시글을_생성하면_임시_게시글은_삭제된다() {
-        final TempArticle tempArticle = tempArticleRepository.save(
-                new TempArticle("title", "content", Category.DISCUSSION.getValue(), member, List.of("spring"), false));
+        final TempArticle tempArticle = tempArticleRepository.save(TempArticle.builder()
+                .title(new Title("title"))
+                .content(new Content("content"))
+                .category(Category.QUESTION)
+                .member(member)
+                .tempTags(new TempTags(List.of("spring")))
+                .isAnonymous(false)
+                .build());
         final ArticleRequest articleRequest = new ArticleRequest("질문합니다.", "내용입니다~!", Category.QUESTION.getValue(),
                 List.of("Spring"), true, tempArticle.getId());
 

--- a/backend/src/test/java/com/woowacourse/gongseek/article/application/TempArticleServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/article/application/TempArticleServiceTest.java
@@ -116,7 +116,8 @@ class TempArticleServiceTest {
                 () -> assertThat(tempArticleDetailResponse.getContent()).isEqualTo("content"),
                 () -> assertThat(tempArticleDetailResponse.getCategory()).isEqualTo("question"),
                 () -> assertThat(tempArticleDetailResponse.getTags()).containsOnly("spring"),
-                () -> assertThat(tempArticleDetailResponse.getIsAnonymous()).isFalse()
+                () -> assertThat(tempArticleDetailResponse.getIsAnonymous()).isFalse(),
+                () -> assertThat(tempArticleDetailResponse.getCreateAt()).isNotNull()
         );
     }
 

--- a/backend/src/test/java/com/woowacourse/gongseek/article/application/TempArticleServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/article/application/TempArticleServiceTest.java
@@ -126,7 +126,7 @@ class TempArticleServiceTest {
                 () -> assertThat(tempArticleDetailResponse.getTitle()).isEqualTo("title"),
                 () -> assertThat(tempArticleDetailResponse.getContent()).isEqualTo("content"),
                 () -> assertThat(tempArticleDetailResponse.getCategory()).isEqualTo("question"),
-                () -> assertThat(tempArticleDetailResponse.getTags()).containsOnly("spring"),
+                () -> assertThat(tempArticleDetailResponse.getTag()).containsOnly("spring"),
                 () -> assertThat(tempArticleDetailResponse.getIsAnonymous()).isFalse(),
                 () -> assertThat(tempArticleDetailResponse.getCreateAt()).isNotNull()
         );

--- a/backend/src/test/java/com/woowacourse/gongseek/article/domain/repository/TempArticleRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/article/domain/repository/TempArticleRepositoryTest.java
@@ -4,9 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.gongseek.article.domain.Category;
+import com.woowacourse.gongseek.article.domain.Content;
 import com.woowacourse.gongseek.article.domain.TempArticle;
-import com.woowacourse.gongseek.config.JpaAuditingConfig;
-import com.woowacourse.gongseek.config.QuerydslConfig;
+import com.woowacourse.gongseek.article.domain.TempTags;
+import com.woowacourse.gongseek.article.domain.Title;
 import com.woowacourse.gongseek.member.domain.Member;
 import com.woowacourse.gongseek.member.domain.repository.MemberRepository;
 import com.woowacourse.gongseek.support.RepositoryTest;
@@ -14,8 +15,6 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
 @RepositoryTest
 class TempArticleRepositoryTest {
@@ -27,16 +26,31 @@ class TempArticleRepositoryTest {
     private TempArticleRepository tempArticleRepository;
 
     private Member member;
+    private TempArticle tempArticle;
 
     @BeforeEach
     public void setUp() {
         member = memberRepository.save(new Member("slow", "hanull", "avatarUrl"));
+        tempArticle = tempArticleRepository.save(TempArticle.builder()
+                .title(new Title("title"))
+                .content(new Content("content"))
+                .category(Category.QUESTION)
+                .member(member)
+                .tempTags(new TempTags(List.of("spring")))
+                .isAnonymous(false)
+                .build());
     }
 
     @Test
     void 임시_게시글을_저장한다() {
-        final TempArticle tempArticle = new TempArticle("title", "content", Category.DISCUSSION.getValue(),
-                member, List.of("spring"), false);
+        final TempArticle tempArticle = TempArticle.builder()
+                .title(new Title("title"))
+                .content(new Content("content"))
+                .category(Category.QUESTION)
+                .member(member)
+                .tempTags(new TempTags(List.of("spring")))
+                .isAnonymous(false)
+                .build();
 
         final TempArticle savedTempArticle = tempArticleRepository.save(tempArticle);
 
@@ -45,26 +59,26 @@ class TempArticleRepositoryTest {
 
     @Test
     void 전체_임시_게시글을_조회한다() {
-        final TempArticle request1 = new TempArticle("title", "content", Category.DISCUSSION.getValue(), member,
-                List.of("spring"), false);
-        final TempArticle request2 = new TempArticle("title2", "content2", Category.QUESTION.getValue(), member,
-                List.of("spring2"), false);
-        tempArticleRepository.save(request1);
-        tempArticleRepository.save(request2);
+        final TempArticle tempArticle2 = TempArticle.builder()
+                .title(new Title("title2"))
+                .content(new Content("content2"))
+                .category(Category.QUESTION)
+                .member(member)
+                .tempTags(new TempTags(List.of("spring2")))
+                .isAnonymous(false)
+                .build();
+        tempArticleRepository.save(tempArticle2);
 
         final List<TempArticle> tempArticles = tempArticleRepository.findAll();
 
         assertAll(
                 () -> assertThat(tempArticles).hasSize(2),
-                () -> assertThat(tempArticles).isEqualTo(List.of(request1, request2))
+                () -> assertThat(tempArticles).isEqualTo(List.of(tempArticle, tempArticle2))
         );
     }
 
     @Test
     void 단건_임시_게시글을_조회한다() {
-        final TempArticle tempArticle = tempArticleRepository.save(
-                new TempArticle("title", "content", Category.DISCUSSION.getValue(), member, List.of("spring"), false));
-
         final TempArticle foundTempArticle = tempArticleRepository.findById(tempArticle.getId())
                 .get();
 
@@ -73,9 +87,6 @@ class TempArticleRepositoryTest {
 
     @Test
     void 임시_게시글을_삭제한다() {
-        final TempArticle tempArticle = tempArticleRepository.save(
-                new TempArticle("title", "content", Category.DISCUSSION.getValue(), member, List.of("spring"), false));
-
         tempArticleRepository.delete(tempArticle);
 
         assertThat(tempArticleRepository.findById(tempArticle.getId())).isEmpty();

--- a/backend/src/test/java/com/woowacourse/gongseek/article/presentation/TempArticleControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/article/presentation/TempArticleControllerTest.java
@@ -116,7 +116,7 @@ class TempArticleControllerTest {
                                 fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
                                 fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
                                 fieldWithPath("category").type(JsonFieldType.STRING).description("카테고리"),
-                                fieldWithPath("tags").type(JsonFieldType.ARRAY).description("해시태그"),
+                                fieldWithPath("tag").type(JsonFieldType.ARRAY).description("해시태그"),
                                 fieldWithPath("isAnonymous").type(JsonFieldType.BOOLEAN).description("익명 여부"),
                                 fieldWithPath("createAt").type(JsonFieldType.STRING).description("생성 날짜")
                         )


### PR DESCRIPTION
변경 사항
- TempArticle @EntityListeners 추가
- 테스트 코드에서만 사용하는 TempArticle 생성자 삭제 및 빌더 패턴 적용
- TempArticleDetailResponse 태그 필드명 변경(tags  -> tag)


Close #580 