### PR TITLE
반응형 커버를 올린다.

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,19 +48,19 @@ const Content = styled.main`
 	min-height: calc(100vh - 2 * ${({ theme }) => theme.size.SIZE_126});
 	padding-bottom: 7rem;
 
-	@media (min-width: 700px) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_SMALL}) {
 		width: calc(100% - ${({ theme }) => theme.size.SIZE_060} * 2);
 		padding: 1rem 5rem;
 		justify-content: space-between;
 	}
 
-	@media (min-width: 1000px) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_MIDDLE}) {
 		width: calc(100% - ${({ theme }) => theme.size.SIZE_110} * 2);
 		padding: 1rem 7rem;
 		justify-content: space-between;
 	}
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		width: calc(100% - ${({ theme }) => theme.size.SIZE_160} * 2);
 		padding: 1rem ${({ theme }) => theme.size.SIZE_160};
 		justify-content: space-between;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,8 @@ const Layout = styled.div`
 	position: relative;
 	height: 100vh;
 	width: 100vw;
+	max-width: 1500px;
+	margin: 0 auto;
 `;
 
 const Content = styled.main`

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,6 +46,18 @@ const Content = styled.main`
 	min-height: calc(100vh - 2 * ${({ theme }) => theme.size.SIZE_126});
 	padding-bottom: 7rem;
 
+	@media (min-width: 700px) {
+		width: calc(100% - ${({ theme }) => theme.size.SIZE_060} * 2);
+		padding: 1rem 5rem;
+		justify-content: space-between;
+	}
+
+	@media (min-width: 1000px) {
+		width: calc(100% - ${({ theme }) => theme.size.SIZE_110} * 2);
+		padding: 1rem 7rem;
+		justify-content: space-between;
+	}
+
 	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
 		width: calc(100% - ${({ theme }) => theme.size.SIZE_160} * 2);
 		padding: 1rem ${({ theme }) => theme.size.SIZE_160};

--- a/frontend/src/components/common/ArticleItem/ArticleItem.styles.tsx
+++ b/frontend/src/components/common/ArticleItem/ArticleItem.styles.tsx
@@ -35,7 +35,7 @@ export const Container = styled.div`
 		cursor: pointer;
 	}
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		height: ${({ theme }) => theme.size.SIZE_220};
 		width: ${({ theme }) => theme.size.SIZE_300};
 	}
@@ -58,7 +58,7 @@ export const ArticleItemTitle = styled.h2`
 		text-decoration: underline;
 	}
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		line-height: 1.5;
 	}
 `;
@@ -152,7 +152,7 @@ export const HashTagListBox = styled.div`
 
 	margin: ${({ theme }) => theme.size.SIZE_020} 0;
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		flex-wrap: wrap;
 	}
 `;

--- a/frontend/src/components/common/CommentInputModal/CommentInputModal.styles.tsx
+++ b/frontend/src/components/common/CommentInputModal/CommentInputModal.styles.tsx
@@ -49,7 +49,7 @@ export const CommentContainer = styled.div`
 
 	animation: ${showSlider} 0.2s ease-in-out;
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		width: 70vw;
 		height: 60vh;
 		margin: 0 auto;
@@ -69,7 +69,7 @@ export const CommentTitle = styled.h2`
 	margin: ${({ theme }) => theme.size.SIZE_016} 0 ${({ theme }) => theme.size.SIZE_016}
 		${({ theme }) => theme.size.SIZE_026};
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		margin-top: ${({ theme }) => theme.size.SIZE_020};
 	}
 `;
@@ -79,7 +79,7 @@ export const CommentContentBox = styled.div`
 	height: 80%;
 	overflow: hidden;
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		height: 40vh;
 	}
 `;
@@ -103,7 +103,7 @@ export const CommentPostButton = styled.button`
 		background-color: ${({ theme }) => theme.colors.PURPLE_400};
 	}
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		width: ${({ theme }) => theme.size.SIZE_160};
 	}
 `;
@@ -118,7 +118,7 @@ export const SubmitBox = styled.div`
 	margin-bottom: ${({ theme }) => theme.size.SIZE_050};
 	width: 80%;
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		width: 100%;
 		display: flex;
 		justify-content: flex-end;

--- a/frontend/src/components/common/SearchBar/SearchBar.styles.tsx
+++ b/frontend/src/components/common/SearchBar/SearchBar.styles.tsx
@@ -30,7 +30,7 @@ export const SearchBarBox = styled.form<{ isSearchOpen: boolean }>`
 		border: ${({ theme }) => theme.size.SIZE_001} solid ${({ theme }) => theme.colors.PURPLE_500};
 	}
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		width: 80%;
 	}
 `;
@@ -64,7 +64,7 @@ export const SearchButton = styled(AiOutlineSearch)`
 		color: ${({ theme }) => theme.colors.PURPLE_400};
 	}
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		font-size: ${({ theme }) => theme.size.SIZE_030};
 	}
 `;

--- a/frontend/src/components/common/SortDropdown/SortDropdown.styles.tsx
+++ b/frontend/src/components/common/SortDropdown/SortDropdown.styles.tsx
@@ -77,7 +77,7 @@ export const Container = styled.div`
 
 	font-size: ${({ theme }) => theme.size.SIZE_012};
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		font-size: ${({ theme }) => theme.size.SIZE_014};
 	}
 `;

--- a/frontend/src/components/layout/Header/Header.styles.tsx
+++ b/frontend/src/components/layout/Header/Header.styles.tsx
@@ -145,7 +145,7 @@ export const NavBarItem = styled(Link)`
 
 export const ProfileIconBox = styled.div`
 	width: fit-content;
-	margin: ${({ theme }) => theme.size.SIZE_004} ${({ theme }) => theme.size.SIZE_160} 0 auto;
+	margin: ${({ theme }) => theme.size.SIZE_004} ${({ theme }) => theme.size.SIZE_040} 0 auto;
 `;
 
 export const LoginIn = styled(Link)`

--- a/frontend/src/components/layout/Header/Header.styles.tsx
+++ b/frontend/src/components/layout/Header/Header.styles.tsx
@@ -69,6 +69,12 @@ export const HeaderSection = styled.header`
 		padding: 1rem ${({ theme }) => theme.size.SIZE_160};
 		justify-content: space-between;
 	}
+
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_MIDDLE}) {
+		width: calc(100% - ${({ theme }) => theme.size.SIZE_080} * 2);
+		padding: 1rem ${({ theme }) => theme.size.SIZE_080};
+		justify-content: space-between;
+	}
 `;
 
 export const LogoLink = styled.h1`
@@ -113,12 +119,12 @@ export const NavBar = styled.nav`
 
 	background-color: ${({ theme }) => theme.colors.WHITE};
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
-		width: calc(100% - ${({ theme }) => theme.size.SIZE_160} * 2);
-
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_SMALL}) {
+		width: calc(100% - ${({ theme }) => theme.size.SIZE_080} * 2);
 		display: flex;
 		visibility: visible;
-
+		padding: 0 ${({ theme }) => theme.size.SIZE_080};
+		margin: 0 auto;
 		justify-content: space-around;
 	}
 `;
@@ -155,7 +161,7 @@ export const LoginIn = styled(Link)`
 	background-color: transparent;
 	color: ${({ theme }) => theme.colors.BLACK_600};
 
-	margin: 0 ${({ theme }) => theme.size.SIZE_160} 0 auto;
+	margin: 0 ${({ theme }) => theme.size.SIZE_032} 0 auto;
 
 	padding: ${({ theme }) => theme.size.SIZE_016};
 

--- a/frontend/src/components/layout/Header/Header.styles.tsx
+++ b/frontend/src/components/layout/Header/Header.styles.tsx
@@ -64,7 +64,7 @@ export const HeaderSection = styled.header`
 
 	padding: 1rem 0;
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		width: calc(100% - ${({ theme }) => theme.size.SIZE_160} * 2);
 		padding: 1rem ${({ theme }) => theme.size.SIZE_160};
 		justify-content: space-between;
@@ -86,7 +86,7 @@ export const LogoImage = styled.img`
 export const SearchBarBox = styled.div`
 	width: 60%;
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		min-width: 40%;
 	}
 `;
@@ -95,7 +95,7 @@ export const SearchOpenBox = styled.div`
 	width: 80%;
 	animation: ${searchOpenMidAnimation} 0.3s ease-in-out;
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		width: 60%;
 		animation: ${searchOpenMaxAnimation} 0.3s ease-in-out;
 	}
@@ -113,7 +113,7 @@ export const NavBar = styled.nav`
 
 	background-color: ${({ theme }) => theme.colors.WHITE};
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		width: calc(100% - ${({ theme }) => theme.size.SIZE_160} * 2);
 
 		display: flex;

--- a/frontend/src/components/layout/TabBar/TabBar.styles.tsx
+++ b/frontend/src/components/layout/TabBar/TabBar.styles.tsx
@@ -20,7 +20,7 @@ export const Section = styled.section`
 	box-shadow: 0px -4px 15px ${({ theme }) => theme.boxShadows.secondary};
 	background-color: ${({ theme }) => theme.colors.WHITE};
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		display: none;
 		visibility: hidden;
 	}

--- a/frontend/src/components/layout/TabBar/TabBar.styles.tsx
+++ b/frontend/src/components/layout/TabBar/TabBar.styles.tsx
@@ -20,7 +20,7 @@ export const Section = styled.section`
 	box-shadow: 0px -4px 15px ${({ theme }) => theme.boxShadows.secondary};
 	background-color: ${({ theme }) => theme.colors.WHITE};
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_SMALL}) {
 		display: none;
 		visibility: hidden;
 	}

--- a/frontend/src/pages/CategoryArticles/CategoryArticles.styles.tsx
+++ b/frontend/src/pages/CategoryArticles/CategoryArticles.styles.tsx
@@ -30,6 +30,16 @@ export const ArticleItemList = styled.div`
 	align-items: center;
 	gap: ${({ theme }) => theme.size.SIZE_024};
 
+	@media (min-width: 700px) {
+		display: grid;
+		width: 100%;
+		grid-template-columns: 1fr 1fr;
+		place-items: center;
+		margin: 0 auto;
+		gap: ${({ theme }) => theme.size.SIZE_022};
+		margin-top: ${({ theme }) => theme.size.SIZE_040};
+	}
+
 	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
 		display: grid;
 		width: 100%;

--- a/frontend/src/pages/CategoryArticles/CategoryArticles.styles.tsx
+++ b/frontend/src/pages/CategoryArticles/CategoryArticles.styles.tsx
@@ -10,7 +10,7 @@ export const Container = styled.div`
 
 	margin: ${({ theme }) => theme.size.SIZE_020} auto;
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		width: 100%;
 	}
 `;
@@ -30,7 +30,7 @@ export const ArticleItemList = styled.div`
 	align-items: center;
 	gap: ${({ theme }) => theme.size.SIZE_024};
 
-	@media (min-width: 700px) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_SMALL}) {
 		display: grid;
 		width: 100%;
 		grid-template-columns: 1fr 1fr;
@@ -40,7 +40,7 @@ export const ArticleItemList = styled.div`
 		margin-top: ${({ theme }) => theme.size.SIZE_040};
 	}
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		display: grid;
 		width: 100%;
 		grid-template-columns: 1fr 1fr 1fr;

--- a/frontend/src/pages/DiscussionDetail/VoteGenerateButton/VoteGenerateButton.tsx
+++ b/frontend/src/pages/DiscussionDetail/VoteGenerateButton/VoteGenerateButton.tsx
@@ -20,7 +20,7 @@ const VoteGenerateButton = styled.button`
 		background-color: ${({ theme }) => theme.colors.PURPLE_400};
 	}
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		width: 30%;
 		margin-top: ${({ theme }) => theme.size.SIZE_040};
 		padding: ${({ theme }) => theme.size.SIZE_012} 0;

--- a/frontend/src/pages/HashTagSearch/HashTagSearchResult/HashTagSearchResult.styles.tsx
+++ b/frontend/src/pages/HashTagSearch/HashTagSearchResult/HashTagSearchResult.styles.tsx
@@ -32,7 +32,7 @@ export const SearchResult = styled.div`
 
 	gap: ${({ theme }) => theme.size.SIZE_014};
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		display: grid;
 		width: 100%;
 		grid-template-columns: 1fr 1fr 1fr;

--- a/frontend/src/pages/HashTagSearch/HashTagSearchResult/HashTagSearchResult.styles.tsx
+++ b/frontend/src/pages/HashTagSearch/HashTagSearchResult/HashTagSearchResult.styles.tsx
@@ -32,6 +32,16 @@ export const SearchResult = styled.div`
 
 	gap: ${({ theme }) => theme.size.SIZE_014};
 
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_SMALL}) {
+		display: grid;
+		width: 100%;
+		grid-template-columns: 1fr 1fr;
+		place-items: center;
+		margin: 0 auto;
+		gap: ${({ theme }) => theme.size.SIZE_022};
+		margin-top: ${({ theme }) => theme.size.SIZE_040};
+	}
+
 	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		display: grid;
 		width: 100%;

--- a/frontend/src/pages/Home/index.styles.tsx
+++ b/frontend/src/pages/Home/index.styles.tsx
@@ -64,6 +64,16 @@ export const ArticleItemList = styled.div`
 
 	margin-top: ${({ theme }) => theme.size.SIZE_024};
 
+	@media (min-width: 700px) {
+		display: grid;
+		width: 100%;
+		grid-template-columns: 1fr 1fr;
+		place-items: center;
+		margin: 0 auto;
+		gap: ${({ theme }) => theme.size.SIZE_022};
+		margin-top: ${({ theme }) => theme.size.SIZE_040};
+	}
+
 	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
 		display: grid;
 		width: 100%;

--- a/frontend/src/pages/Home/index.styles.tsx
+++ b/frontend/src/pages/Home/index.styles.tsx
@@ -74,7 +74,7 @@ export const ArticleItemList = styled.div`
 		margin-top: ${({ theme }) => theme.size.SIZE_040};
 	}
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		display: grid;
 		width: 100%;
 		grid-template-columns: 1fr 1fr 1fr;

--- a/frontend/src/pages/MyPage/UserItemBox/UserItemBox.styles.tsx
+++ b/frontend/src/pages/MyPage/UserItemBox/UserItemBox.styles.tsx
@@ -27,7 +27,7 @@ export const HeaderLine = styled.div`
 
 	padding: ${({ theme }) => theme.size.SIZE_010};
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		width: 50%;
 	}
 `;
@@ -70,7 +70,7 @@ export const ChildrenBox = styled.div`
 
 	gap: ${({ theme }) => theme.size.SIZE_020};
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		width: 50%;
 	}
 `;

--- a/frontend/src/pages/MyPage/index.styles.tsx
+++ b/frontend/src/pages/MyPage/index.styles.tsx
@@ -6,7 +6,7 @@ export const Container = styled.section`
 
 	width: 100%;
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		gap: ${({ theme }) => theme.size.SIZE_100};
 	}
 `;
@@ -25,7 +25,7 @@ export const ContentContainer = styled.div`
 
 	gap: ${({ theme }) => theme.size.SIZE_040};
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		gap: ${({ theme }) => theme.size.SIZE_056};
 	}
 `;

--- a/frontend/src/pages/Search/SearchResult/SearchResult.styles.tsx
+++ b/frontend/src/pages/Search/SearchResult/SearchResult.styles.tsx
@@ -23,7 +23,7 @@ export const SearchResultBox = styled.div`
 	align-items: center;
 	gap: ${({ theme }) => theme.size.SIZE_020};
 
-	@media (min-width: 700px) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_SMALL}) {
 		display: grid;
 		width: 100%;
 		grid-template-columns: 1fr 1fr;
@@ -33,7 +33,7 @@ export const SearchResultBox = styled.div`
 		margin-top: ${({ theme }) => theme.size.SIZE_040};
 	}
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		width: 100%;
 		display: grid;
 		grid-template-columns: 1fr 1fr 1fr;

--- a/frontend/src/pages/Search/SearchResult/SearchResult.styles.tsx
+++ b/frontend/src/pages/Search/SearchResult/SearchResult.styles.tsx
@@ -23,6 +23,16 @@ export const SearchResultBox = styled.div`
 	align-items: center;
 	gap: ${({ theme }) => theme.size.SIZE_020};
 
+	@media (min-width: 700px) {
+		display: grid;
+		width: 100%;
+		grid-template-columns: 1fr 1fr;
+		place-items: center;
+		margin: 0 auto;
+		gap: ${({ theme }) => theme.size.SIZE_022};
+		margin-top: ${({ theme }) => theme.size.SIZE_040};
+	}
+
 	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
 		width: 100%;
 		display: grid;

--- a/frontend/src/pages/VoteDeadlineGenerator/index.styles.tsx
+++ b/frontend/src/pages/VoteDeadlineGenerator/index.styles.tsx
@@ -69,7 +69,7 @@ export const SubmitButton = styled.button`
 		background-color: ${({ theme }) => theme.colors.PURPLE_400};
 	}
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		width: ${({ theme }) => theme.size.SIZE_100};
 		height: ${({ theme }) => theme.size.SIZE_040};
 

--- a/frontend/src/pages/VoteGenerator/AddedOption/AddedOption.tsx
+++ b/frontend/src/pages/VoteGenerator/AddedOption/AddedOption.tsx
@@ -36,7 +36,7 @@ const Trash = styled(AiFillDelete)`
 	:hover {
 		color: ${({ theme }) => theme.colors.RED_500};
 	}
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		font-size: ${({ theme }) => theme.size.SIZE_020};
 	}
 `;

--- a/frontend/src/pages/VoteGenerator/index.styles.tsx
+++ b/frontend/src/pages/VoteGenerator/index.styles.tsx
@@ -27,7 +27,7 @@ export const ContentForm = styled.form`
 	width: 100%;
 	height: 100%;
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		width: 60%;
 		margin-top: ${({ theme }) => theme.size.SIZE_050};
 	}
@@ -41,7 +41,7 @@ export const OptionInputBox = styled.div`
 
 	width: 90%;
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		width: 50%;
 	}
 `;
@@ -82,7 +82,7 @@ export const SubmitButton = styled.button`
 		background-color: ${({ theme }) => theme.colors.PURPLE_400};
 	}
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		width: 40%;
 		padding: ${({ theme }) => theme.size.SIZE_008};
 		font-size: ${({ theme }) => theme.size.SIZE_014};

--- a/frontend/src/pages/WritingArticles/index.styles.tsx
+++ b/frontend/src/pages/WritingArticles/index.styles.tsx
@@ -12,7 +12,8 @@ export const Container = styled.div`
 
 	width: 100%;
 	min-height: 100%;
-
+	max-width: 900px;
+	margin: 0 auto;
 	margin-bottom: ${({ theme }) => theme.size.SIZE_040};
 `;
 
@@ -31,7 +32,7 @@ export const SelectorBox = styled.div`
 	flex-direction: column;
 	gap: ${({ theme }) => theme.size.SIZE_010};
 
-	width: 90%;
+	width: 95%;
 
 	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
 		width: 100%;

--- a/frontend/src/pages/WritingArticles/index.styles.tsx
+++ b/frontend/src/pages/WritingArticles/index.styles.tsx
@@ -21,7 +21,7 @@ export const Content = styled.div`
 	width: 100%;
 	margin-top: ${({ theme }) => theme.size.SIZE_028};
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		width: 100%;
 	}
 `;
@@ -34,7 +34,7 @@ export const SelectorBox = styled.div`
 
 	width: 95%;
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		width: 100%;
 	}
 `;
@@ -50,7 +50,7 @@ export const TitleInput = styled.input`
 
 	padding: 0.6rem 0.8rem;
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		font-size: ${({ theme }) => theme.size.SIZE_020};
 		padding: 1.3rem 0.8rem;
 	}
@@ -87,7 +87,7 @@ export const OptionBox = styled.div`
 	flex-direction: column;
 	gap: ${({ theme }) => theme.size.SIZE_010};
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		flex-direction: row-reverse;
 	}
 `;
@@ -162,7 +162,7 @@ export const SubmitButton = styled.button`
 		background-color: ${({ theme }) => theme.colors.PURPLE_400};
 	}
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		width: ${({ theme }) => theme.size.SIZE_100};
 		height: ${({ theme }) => theme.size.SIZE_040};
 
@@ -176,7 +176,7 @@ export const UpdateSubmitBox = styled.div`
 	width: 100%;
 	justify-content: center;
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		justify-content: flex-end;
 	}
 `;
@@ -203,7 +203,7 @@ export const UpdateSubmitButton = styled.button`
 		background-color: ${({ theme }) => theme.colors.PURPLE_400};
 	}
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		width: ${({ theme }) => theme.size.SIZE_100};
 		height: ${({ theme }) => theme.size.SIZE_040};
 
@@ -244,7 +244,7 @@ export const SubmitBox = styled.div`
 	margin-top: ${({ theme }) => theme.size.SIZE_050};
 	width: 85%;
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP}) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {
 		margin-left: auto;
 		width: min-content;
 	}

--- a/frontend/src/styles/Theme.ts
+++ b/frontend/src/styles/Theme.ts
@@ -41,7 +41,9 @@ export const articleColors = {
 
 const breakpoints = {
 	MOBIL: '320px',
-	DESKTOP: '1280px',
+	DESKTOP_SMALL: '700px',
+	DESKTOP_MIDDLE: '1000px',
+	DESKTOP_LARGE: '1280px',
 };
 
 const boxShadows = {

--- a/frontend/src/styles/reset.tsx
+++ b/frontend/src/styles/reset.tsx
@@ -116,7 +116,11 @@ export const reset = css`
 		@media (min-width: 420px) {
 			font-size: 3vw;
 		}
-		@media (min-width: 1280px) {
+
+		@media (min-width: 700px) {
+			font-size: 2vw;
+		}
+		@media (min-width: 1000px) {
 			font-size: 100%;
 		}
 	}


### PR DESCRIPTION
close #585 

## 구현사항

현재 1280px이상, 그 외의 상태로 모든 반응형을 처리하고 있어 700px, 1000px에 대해서 중간과정을 더 넣어서 자연스럽도록 구현하였습니다.

- 기본 모바일 (700px) 이하
<img width="668" alt="스크린샷 2022-09-20 오후 10 51 48" src="https://user-images.githubusercontent.com/85891751/191279083-701eb4f6-cd3d-439f-8e93-c73ca23bb135.png">

<img width="651" alt="스크린샷 2022-09-20 오후 11 23 55" src="https://user-images.githubusercontent.com/85891751/191284288-50e23cf7-c664-4290-9269-ef566b77f44a.png">


- 700px이상 1000px 이하
<img width="757" alt="스크린샷 2022-09-20 오후 11 05 54" src="https://user-images.githubusercontent.com/85891751/191279477-2057ce82-5955-4184-bcd1-780500c2b799.png">

<img width="651" alt="스크린샷 2022-09-20 오후 11 23 55" src="https://user-images.githubusercontent.com/85891751/191284151-eaa39205-6de3-4e09-a363-37b6346fdb30.png">


- 1000px 이상 1280px이하
<img width="1107" alt="스크린샷 2022-09-20 오후 11 05 23" src="https://user-images.githubusercontent.com/85891751/191279537-ab2e6af7-6cdb-4cdc-a7f0-df6e2013e902.png">

<img width="1019" alt="스크린샷 2022-09-20 오후 11 24 10" src="https://user-images.githubusercontent.com/85891751/191284065-e83fab5c-f261-41a2-b533-3790e1d1c921.png">


- 1280px 이상
<img width="1791" alt="스크린샷 2022-09-20 오후 10 52 08" src="https://user-images.githubusercontent.com/85891751/191279575-fdff3eac-46c3-42a4-b63c-c442e781a059.png">

<img width="1539" alt="스크린샷 2022-09-20 오후 11 26 45" src="https://user-images.githubusercontent.com/85891751/191284678-a2f7426b-9804-4cac-9f64-32d9071816a8.png">



현재 사이트의 너비가 모니터의 크기에따라 끝까지 늘어나기때문에 매우 큰 모니터를 사용하게 될시 컴포넌트가 굉장히 길어지는 문제가 발생하여`max-width` 를 1500px을 주어서 해결하였습니다.

WritingArticles또한 `max-width` 를 900px로 주어서 너무 길어지는 문제를 방지하였습니다!

<img width="1234" alt="스크린샷 2022-09-20 오후 11 28 37" src="https://user-images.githubusercontent.com/85891751/191285245-5b4ed0e0-3650-4f13-8cd4-e93e71873dd5.png">

<img width="1792" alt="스크린샷 2022-09-20 오후 11 28 46" src="https://user-images.githubusercontent.com/85891751/191285327-f39a97b6-5387-46a2-9aa8-7e4f1dfd3785.png">

네이버 역시 동일하게 max-width를 주어서 일정이상 부터는 양옆의 여백이 생기도록 관리하는것을 보고 참고하였습니다!

## 리뷰 중점사항

- 탭바에 대해서 언제부터 생기게 해야될지 포인트를 정해야될것 같습니다.
- 현재 700, 1000, 1280 이런 숫자로 나누어지는데 자연스러운 기준을 정한것이여서 한번 괜찮은지 봐주셨으면 합니다!
- 700, 1000, 1280을 DESKTOP_SMALL, DESKTOP_MIDDLE, DESKTOP_LARGE라는 상수로 관리하려는데 어떻게 생각하시나요?
- 다른 반응형 더 처리해야될것 있으면 코멘트로 날려주세요.