### PR TITLE
리프레시 토큰 발급할 때, 액유효하지 않는 액세스토큰 에러 코드 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongseek/auth/application/TokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/auth/application/TokenProvider.java
@@ -8,5 +8,5 @@ public interface TokenProvider {
 
     boolean isValidAccessToken(String token);
 
-    boolean isValidAccessTokenWithTimeOut(String token);
+    void isValidAccessTokenWithTimeOut(String token);
 }

--- a/backend/src/main/java/com/woowacourse/gongseek/auth/exception/InvalidAccessTokenAtRenewException.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/auth/exception/InvalidAccessTokenAtRenewException.java
@@ -1,0 +1,6 @@
+package com.woowacourse.gongseek.auth.exception;
+
+import com.woowacourse.gongseek.common.exception.UnAuthorizedException;
+
+public class InvalidAccessTokenAtRenewException extends UnAuthorizedException {
+}

--- a/backend/src/main/java/com/woowacourse/gongseek/auth/infra/JwtTokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/auth/infra/JwtTokenProvider.java
@@ -1,6 +1,7 @@
 package com.woowacourse.gongseek.auth.infra;
 
 import com.woowacourse.gongseek.auth.application.TokenProvider;
+import com.woowacourse.gongseek.auth.exception.InvalidAccessTokenAtRenewException;
 import com.woowacourse.gongseek.auth.exception.InvalidAccessTokenException;
 import com.woowacourse.gongseek.common.exception.UnAuthorizedTokenException;
 import io.jsonwebtoken.Claims;
@@ -64,14 +65,13 @@ public class JwtTokenProvider implements TokenProvider {
     }
 
     @Override
-    public boolean isValidAccessTokenWithTimeOut(String token) {
+    public void isValidAccessTokenWithTimeOut(String token) {
         try {
             getClaimsJws(token, tokenSecretKey).getBody();
             throw new UnAuthorizedTokenException();
-        } catch (ExpiredJwtException e) {
-            return true;
+        } catch (ExpiredJwtException ignored) {
         } catch (JwtException | IllegalArgumentException e) {
-            throw new InvalidAccessTokenException();
+            throw new InvalidAccessTokenAtRenewException();
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/gongseek/auth/presentation/RefreshTokenInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/auth/presentation/RefreshTokenInterceptor.java
@@ -24,13 +24,7 @@ public class RefreshTokenInterceptor implements HandlerInterceptor {
         }
 
         String accessToken = TokenExtractor.extract(request.getHeader(HttpHeaders.AUTHORIZATION));
-        validateAccessToken(accessToken);
+        jwtTokenProvider.isValidAccessTokenWithTimeOut(accessToken);
         return true;
-    }
-
-    private void validateAccessToken(String accessToken) {
-        if (!jwtTokenProvider.isValidAccessTokenWithTimeOut(accessToken)) {
-            throw new UnAuthorizedTokenException();
-        }
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongseek/common/exception/ExceptionType.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/common/exception/ExceptionType.java
@@ -11,6 +11,7 @@ import com.woowacourse.gongseek.auth.exception.EmptyTokenException;
 import com.woowacourse.gongseek.auth.exception.GithubAccessTokenLoadFailException;
 import com.woowacourse.gongseek.auth.exception.GithubUserProfileLoadFailException;
 import com.woowacourse.gongseek.auth.exception.HttpRequestNullException;
+import com.woowacourse.gongseek.auth.exception.InvalidAccessTokenAtRenewException;
 import com.woowacourse.gongseek.auth.exception.InvalidAccessTokenException;
 import com.woowacourse.gongseek.auth.exception.InvalidRefreshTokenException;
 import com.woowacourse.gongseek.auth.exception.InvalidTokenTypeException;
@@ -54,6 +55,7 @@ public enum ExceptionType {
     NOT_MEMBER_EXCEPTION("1008", "회원이 아니므로 권한이 없습니다.", NotMemberException.class),
     INVALID_REFRESH_TOKEN_EXCEPTION("1009", "리프레시 토큰이 유효하지 않습니다.", InvalidRefreshTokenException.class),
     UNAUTHORIZED_TOKEN_EXCEPTION("1010", "유효한 액세스 토큰으로 리프레시 토큰을 발급할 수 없습니다.", UnAuthorizedTokenException.class),
+    INVALID_ACCESS_TOKEN_AT_RENEW_EXCEPTION("1011", "유효하지 않는 액세스 토큰으로 권한이 없는 유저입니다. 재로그인을 해주세요", InvalidAccessTokenAtRenewException.class),
 
     MEMBER_NOT_FOUND_EXCEPTION("2001", "회원이 존재하지 않습니다.", MemberNotFoundException.class),
     NAME_NULL_OR_EMPTY_EXCEPTION("2002", "회원의 이름은 1자 이상이어야 합니다.", NameNullOrEmptyException.class),

--- a/backend/src/test/java/com/woowacourse/gongseek/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/acceptance/AuthAcceptanceTest.java
@@ -64,8 +64,8 @@ public class AuthAcceptanceTest extends AcceptanceTest {
 
         //then
         assertAll(
-                () -> assertThat(errorResponse.getErrorCode()).isEqualTo("1005"),
-                () -> assertThat(errorResponse.getMessage()).isEqualTo("엑세스 토큰이 유효하지 않습니다.")
+                () -> assertThat(errorResponse.getErrorCode()).isEqualTo("1011"),
+                () -> assertThat(errorResponse.getMessage()).isEqualTo("유효하지 않는 액세스 토큰으로 권한이 없는 유저입니다. 재로그인을 해주세요")
         );
     }
 

--- a/backend/src/test/java/com/woowacourse/gongseek/auth/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/auth/presentation/AuthControllerTest.java
@@ -2,6 +2,8 @@ package com.woowacourse.gongseek.auth.presentation;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
@@ -102,7 +104,7 @@ class AuthControllerTest {
     void 토큰_재발급_API_문서화() throws Exception {
         UUID refreshToken = UUID.randomUUID();
 
-        given(jwtTokenProvider.isValidAccessTokenWithTimeOut(any())).willReturn(true);
+        doNothing().when(jwtTokenProvider).isValidAccessTokenWithTimeOut(any());
 
         given(authService.renewToken(any())).willReturn(
                 TokenResponse.builder()


### PR DESCRIPTION
- 액세스 토큰 에러 코드 상세화했습니다.
- 1011번 추가했습니다.

Close #589 