### PR TITLE
임시 게시글 업데이트 시 발생하는 오류 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongseek/article/domain/TempArticle.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/article/domain/TempArticle.java
@@ -2,7 +2,6 @@ package com.woowacourse.gongseek.article.domain;
 
 import com.woowacourse.gongseek.member.domain.Member;
 import java.time.LocalDateTime;
-import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -66,12 +65,8 @@ public class TempArticle {
         this.title = tempArticle.getTitle();
         this.content = tempArticle.getContent();
         this.category = tempArticle.getCategory();
-        this.tempTags = new TempTags(tempArticle.getTempTags());
+        this.tempTags = tempArticle.getTempTags();
         this.isAnonymous = tempArticle.isAnonymous;
         this.createdAt = LocalDateTime.now();
-    }
-
-    public List<String> getTempTags() {
-        return tempTags.toResponse();
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongseek/article/domain/TempTags.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/article/domain/TempTags.java
@@ -5,6 +5,7 @@ import com.woowacourse.gongseek.tag.exception.ExceededTagSizeException;
 import com.woowacourse.gongseek.tag.exception.TagNameLengthException;
 import com.woowacourse.gongseek.tag.exception.TagNameNullOrBlankException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -75,6 +76,9 @@ public class TempTags {
     }
 
     public List<String> toResponse() {
+        if (values.isBlank()) {
+            return Collections.emptyList();
+        }
         return Arrays.asList(values.split(TEMP_TAG_NAME_DELIMITER));
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongseek/article/presentation/dto/TempArticleDetailResponse.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/article/presentation/dto/TempArticleDetailResponse.java
@@ -37,7 +37,7 @@ public class TempArticleDetailResponse {
                 .title(tempArticle.getTitle().getValue())
                 .content(tempArticle.getContent().getValue())
                 .category(tempArticle.getCategory().getValue())
-                .tag(tempArticle.getTempTags())
+                .tag(tempArticle.getTempTags().toResponse())
                 .isAnonymous(tempArticle.isAnonymous())
                 .createAt(tempArticle.getCreatedAt())
                 .build();

--- a/backend/src/test/java/com/woowacourse/gongseek/acceptance/support/fixtures/TempArticleFixture.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/acceptance/support/fixtures/TempArticleFixture.java
@@ -10,7 +10,7 @@ import org.springframework.http.MediaType;
 
 public class TempArticleFixture {
 
-    public static ExtractableResponse<Response> 임시_게시물을_등록한다(AccessTokenResponse tokenResponse,
+    public static ExtractableResponse<Response> 임시_게시글을_등록한다(AccessTokenResponse tokenResponse,
                                                              ArticleRequest request) {
         return RestAssured
                 .given().log().all()
@@ -19,6 +19,15 @@ public class TempArticleFixture {
                 .body(request)
                 .when()
                 .post("/api/temp-articles")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 임시_게시글_단건_조회한다(AccessTokenResponse tokenResponse, long tempArticleId) {
+        return RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokenResponse.getAccessToken())
+                .when()
+                .get("/api/temp-articles/{tempArticleId}", tempArticleId)
                 .then().log().all()
                 .extract();
     }

--- a/backend/src/test/java/com/woowacourse/gongseek/article/application/TempArticleServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/article/application/TempArticleServiceTest.java
@@ -89,7 +89,7 @@ class TempArticleServiceTest {
                 () -> assertThat(updatedId.getId()).isEqualTo(tempArticle.getId()),
                 () -> assertThat(tempArticle.getTitle().getValue()).isEqualTo("updateTitle"),
                 () -> assertThat(tempArticle.getContent().getValue()).isEqualTo("updateContent"),
-                () -> assertThat(tempArticle.getTempTags().get(0)).isEqualTo("updateSpring"),
+                () -> assertThat(tempArticle.getTempTags().toResponse().get(0)).isEqualTo("updateSpring"),
                 () -> assertThat(tempArticle.isAnonymous()).isFalse()
         );
     }


### PR DESCRIPTION
## 변경 사항
- 임시 게시글 태그가 빈 경우(""), 빈 리스트를 반환하도록 변경
- 임시 게시글 단건 조회 픽스처로 분리
- 임시 게시글 수정 인수 테스트 추가

Close #592 