### PR TITLE
글을 수정한 후 내용이 바로 보여지지 않고 있음

### DIFF
--- a/frontend/src/hooks/article/useGetDetailArticle.tsx
+++ b/frontend/src/hooks/article/useGetDetailArticle.tsx
@@ -15,7 +15,6 @@ const useGetDetailArticle = (id: string) => {
 		AxiosError<{ errorCode: keyof typeof ErrorMessage; message: string }>
 	>(['detail-article', `article${id}`], () => getDetailArticle(id), {
 		retry: false,
-		refetchOnWindowFocus: false,
 	});
 	const setTempArticle = useSetRecoilState(articleState);
 

--- a/frontend/src/hooks/comment/usePutCommentInputModal.tsx
+++ b/frontend/src/hooks/comment/usePutCommentInputModal.tsx
@@ -32,6 +32,7 @@ const usePutCommentInputModal = (closeModal: CommentInputModalProps['closeModal'
 		if (isSuccess) {
 			showSnackBar('댓글이 수정되었습니다');
 			closeModal();
+			window.location.reload();
 		}
 	}, [isSuccess]);
 


### PR DESCRIPTION
Close #418 

글을 수정한 후 최신 상태를 보여주기 위해서 window.location.reload와 href를 사용함 

* Toast Viewer가 Ref를 사용하고 있어서 해당 값이 props로 제대로 전달되지 않고 업데이트가 이루어지지 않음 그래서 리로드하는 방식으로 문제 해결