### PR TITLE
로그아웃을 구현한다

### DIFF
--- a/frontend/src/api/login.ts
+++ b/frontend/src/api/login.ts
@@ -37,3 +37,12 @@ export const getAccessTokenByRefreshToken = async () => {
 	});
 	return response.data;
 };
+
+export const deleteRefreshToken = () =>
+	axios.delete(`${HOME_URL}/api/auth/logout`, {
+		headers: {
+			'Access-Control-Allow-Origin': '*',
+			'Access-Control-Allow-Credentials': true,
+		},
+		withCredentials: true,
+	});

--- a/frontend/src/components/common/Dropdown/Dropdown.tsx
+++ b/frontend/src/components/common/Dropdown/Dropdown.tsx
@@ -2,13 +2,16 @@ import { useNavigate } from 'react-router-dom';
 
 import * as S from '@/components/common/Dropdown/Dropdown.styles';
 import { ACCESSTOKEN_KEY } from '@/constants';
+import useDeleteRefreshToken from '@/hooks/login/useDeleteRefreshToken';
 
 const Dropdown = ({ onClickCloseDropdown }: { onClickCloseDropdown: () => void }) => {
 	const navigate = useNavigate();
+	const { mutate: mutateDeleteRefreshToken } = useDeleteRefreshToken();
 
 	const onLogOutClick = () => {
 		if (window.confirm('정말로 로그아웃을 하시겠습니까?')) {
 			localStorage.removeItem(ACCESSTOKEN_KEY);
+			mutateDeleteRefreshToken();
 			window.location.href = '/';
 			return;
 		}

--- a/frontend/src/components/common/MenuSlider/MenuSlider.tsx
+++ b/frontend/src/components/common/MenuSlider/MenuSlider.tsx
@@ -21,9 +21,9 @@ const MenuSlider = ({ closeSlider }: MenuSliderProps) => {
 
 	const onLogoutClick = () => {
 		if (confirm('정말로 로그아웃 하시겠습니까?')) {
-			localStorage.removeItem(ACCESSTOKEN_KEY);
 			mutateDeleteRefreshToken();
-			window.location.href = URL.HOME;
+			localStorage.removeItem(ACCESSTOKEN_KEY);
+			navigate(URL.HOME);
 		}
 	};
 

--- a/frontend/src/components/common/MenuSlider/MenuSlider.tsx
+++ b/frontend/src/components/common/MenuSlider/MenuSlider.tsx
@@ -5,6 +5,7 @@ import { useRecoilValue } from 'recoil';
 import * as S from '@/components/common/MenuSlider/MenuSlider.styles';
 import { ACCESSTOKEN_KEY } from '@/constants';
 import { URL } from '@/constants/url';
+import useDeleteRefreshToken from '@/hooks/login/useDeleteRefreshToken';
 import { getUserIsLogin } from '@/store/userState';
 
 export interface MenuSliderProps {
@@ -14,12 +15,14 @@ export interface MenuSliderProps {
 const MenuSlider = ({ closeSlider }: MenuSliderProps) => {
 	const menuSlider = document.getElementById('menu-slider');
 	const isLogin = useRecoilValue(getUserIsLogin);
+	const { mutate: mutateDeleteRefreshToken } = useDeleteRefreshToken();
 
 	const navigate = useNavigate();
 
 	const onLogoutClick = () => {
 		if (confirm('정말로 로그아웃 하시겠습니까?')) {
 			localStorage.removeItem(ACCESSTOKEN_KEY);
+			mutateDeleteRefreshToken();
 			window.location.href = URL.HOME;
 		}
 	};

--- a/frontend/src/components/helper/LogicErrorBoundary.tsx
+++ b/frontend/src/components/helper/LogicErrorBoundary.tsx
@@ -35,14 +35,15 @@ class LogicErrorBoundary extends CommonErrorBoundary<LogicErrorBoundaryProps> {
 			return;
 		}
 
-		const { showSnackBar, navigate } = this.props;
+		const { showSnackBar, navigate, mutateDeleteRefreshToken } = this.props;
 
 		const errorCode = this.state.error.errorCode;
 
 		if (
 			typeof errorCode === 'undefined' ||
 			typeof showSnackBar === 'undefined' ||
-			typeof navigate === 'undefined'
+			typeof navigate === 'undefined' ||
+			typeof mutateDeleteRefreshToken == 'undefined'
 		) {
 			throw new CustomError('9999', '빠진 인자가 없는지 확인해주세요');
 		}
@@ -79,6 +80,7 @@ class LogicErrorBoundary extends CommonErrorBoundary<LogicErrorBoundaryProps> {
 
 		if (isInvalidRefreshTokenError(errorCode)) {
 			localStorage.removeItem(ACCESSTOKEN_KEY);
+			mutateDeleteRefreshToken();
 			window.location.href = URL.HOME;
 		}
 		showSnackBar(errorMessage);

--- a/frontend/src/components/helper/types/ErrorBoundary.type.ts
+++ b/frontend/src/components/helper/types/ErrorBoundary.type.ts
@@ -1,6 +1,9 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { UseMutateFunction } from 'react-query';
 import { NavigateFunction } from 'react-router-dom';
 
 import CustomError from '@/components/helper/CustomError';
+import { ErrorMessage } from '@/constants/ErrorMessage';
 
 export interface ErrorBoundaryProps {
 	children?: React.ReactNode;
@@ -13,6 +16,18 @@ export interface ErrorBoundaryState {
 export interface LogicErrorBoundaryProps extends ErrorBoundaryProps {
 	showSnackBar?: (message: string) => void;
 	navigate?: NavigateFunction;
+	mutateDeleteRefreshToken?: UseMutateFunction<
+		AxiosResponse<null, any>,
+		AxiosError<
+			{
+				errorCode: keyof typeof ErrorMessage;
+				message: string;
+			},
+			any
+		>,
+		void,
+		unknown
+	>;
 }
 
 export interface FallbackErrorBoundaryProps {

--- a/frontend/src/hooks/login/useDeleteRefreshToken.tsx
+++ b/frontend/src/hooks/login/useDeleteRefreshToken.tsx
@@ -1,0 +1,19 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { useMutation } from 'react-query';
+
+import { deleteRefreshToken } from '@/api/login';
+import { ErrorMessage } from '@/constants/ErrorMessage';
+import useThrowCustomError from '@/hooks/common/useThrowCustomError';
+
+const useDeleteRefreshToken = () => {
+	const { isSuccess, isError, error, mutate } = useMutation<
+		AxiosResponse<null>,
+		AxiosError<{ errorCode: keyof typeof ErrorMessage; message: string }>
+	>('refresh-delete', deleteRefreshToken);
+
+	useThrowCustomError(isError, error);
+
+	return { isSuccess, mutate };
+};
+
+export default useDeleteRefreshToken;

--- a/frontend/src/utils/withHooksHOC.tsx
+++ b/frontend/src/utils/withHooksHOC.tsx
@@ -1,13 +1,22 @@
 import { useNavigate } from 'react-router-dom';
 
 import useSnackBar from '@/hooks/common/useSnackBar';
+import useDeleteRefreshToken from '@/hooks/login/useDeleteRefreshToken';
 
 function WithHooksHOC<F>(Component: React.ComponentType<F>) {
 	return function Hoc(props: F) {
 		const { showSnackBar } = useSnackBar();
 		const navigate = useNavigate();
+		const { mutate: mutateDeleteRefreshToken } = useDeleteRefreshToken();
 
-		return <Component {...props} showSnackBar={showSnackBar} navigate={navigate} />;
+		return (
+			<Component
+				{...props}
+				showSnackBar={showSnackBar}
+				navigate={navigate}
+				mutateDeleteRefreshToken={mutateDeleteRefreshToken}
+			/>
+		);
 	};
 }
 


### PR DESCRIPTION
Close #595 

로그아웃시, 리프레시 토큰을 삭제하는 서버 요청을 보냄
에러바운더리에서도 삭제 요청을 보내기 위해서 mutate를 HOC에서 props로 에러바운더리로 넘김 

로그아웃 요청을 보내기 전에 페이지가 refresh 되어버려서 navigate로 동작 방식 고침 