### PR TITLE
글 작성 페이지에서 새로고침을 막는다

### DIFF
--- a/frontend/src/pages/WritingArticles/index.tsx
+++ b/frontend/src/pages/WritingArticles/index.tsx
@@ -59,6 +59,16 @@ const WritingArticles = ({ tempId = '' }: { tempId?: '' | number }) => {
 	}, []);
 
 	useEffect(() => {
+		(() => {
+			window.addEventListener('beforeunload', preventRefresh);
+		})();
+
+		return () => {
+			window.removeEventListener('beforeunload', preventRefresh);
+		};
+	}, []);
+
+	useEffect(() => {
 		if (isTempDetailArticleSuccess && tempArticleData && tempArticleData.data) {
 			setTitle(tempArticleData.data.title);
 			setHashTags(tempArticleData.data.tag.filter((item) => item !== ''));
@@ -100,6 +110,11 @@ const WritingArticles = ({ tempId = '' }: { tempId?: '' | number }) => {
 				content: content.current?.getInstance().getMarkdown(),
 			});
 		}
+	};
+
+	const preventRefresh = (e: BeforeUnloadEvent) => {
+		e.preventDefault();
+		e.returnValue = '';
 	};
 
 	return (


### PR DESCRIPTION
Close #625


글 작성 페이지에서 새로고침시, 임시저장되지 않은 내용들이 날아갈 수 있기 때문에 

window의 beforeunload 이벤트를 활용하여 새로고침 전에 막는 단계를 거친다
