### PR TITLE
검색결과가 없을시 서버에러가 발생하는것 수정 

### DIFF
--- a/frontend/src/api/search.ts
+++ b/frontend/src/api/search.ts
@@ -55,7 +55,7 @@ export const getArticleSearchResult = async ({
 			},
 		},
 	);
-	console.log(data.articles, data.articles.length);
+
 	return {
 		articles: data.articles,
 		hasNext: data.hasNext,

--- a/frontend/src/api/search.ts
+++ b/frontend/src/api/search.ts
@@ -55,11 +55,11 @@ export const getArticleSearchResult = async ({
 			},
 		},
 	);
-
+	console.log(data.articles, data.articles.length);
 	return {
 		articles: data.articles,
 		hasNext: data.hasNext,
-		cursorId: String(data.articles[data.articles.length - 1].id),
+		cursorId: String(data.articles[data.articles.length - 1]?.id),
 		target: target,
 		searchIndex,
 	};


### PR DESCRIPTION
close #629 

검색결과에서 undefined일 경우 id를 참조하여 발생하는 에러얐다. 

optional operator를 이용하여 처리하였다.