### PR TITLE
유저에 대한 검색 결과가 없을 때에 페이지가 보이지 않는 것에 대해 수정한다

### DIFF
--- a/frontend/src/api/search.ts
+++ b/frontend/src/api/search.ts
@@ -28,7 +28,10 @@ export const getUserSearchResult = async ({
 	return {
 		articles: data.articles,
 		hasNext: data.hasNext,
-		cursorId: String(data.articles[data.articles.length - 1].id),
+		cursorId:
+			data.articles && data.articles[data.articles.length - 1]
+				? String(data.articles[data.articles.length - 1].id)
+				: '',
 		target: target,
 		searchIndex,
 	};
@@ -59,7 +62,10 @@ export const getArticleSearchResult = async ({
 	return {
 		articles: data.articles,
 		hasNext: data.hasNext,
-		cursorId: String(data.articles[data.articles.length - 1]?.id),
+		cursorId:
+			data.articles && data.articles[data.articles.length - 1]
+				? String(data.articles[data.articles.length - 1].id)
+				: '',
 		target: target,
 		searchIndex,
 	};
@@ -86,7 +92,10 @@ export const getArticleByHashTag = async ({
 	return {
 		articles: data.articles,
 		hasNext: data.hasNext,
-		cursorId: String(data.articles[data.articles.length - 1].id),
+		cursorId:
+			data.articles && data.articles[data.articles.length - 1]
+				? String(data.articles[data.articles.length - 1].id)
+				: '',
 		hashTags: hashTags,
 	};
 };


### PR DESCRIPTION
Close #631 

무한스크롤 구현을 위해서 cursorId 를 api 함수부분에서 return 하고 있었는데 
검색결과가 없을때에는 cursorId를 받아올 수 없어서 에러가 발생하고 있었다. 
해당 부분을 방지하기 위해서 타입가드를 진행하여 검색결과가 없을 때에는 빈문자열을 넣어주었다