### PR TITLE
토론, 질문 카테고리에서 좋아요 순으로 정렬이 되도록 한다 

### DIFF
--- a/frontend/src/api/article.ts
+++ b/frontend/src/api/article.ts
@@ -72,7 +72,13 @@ export const getAllArticle = async ({
 		return data;
 	}
 
-	const data = getAllArticleByViewsOrLatest({ category, sort, cursorId, cursorViews, accessToken });
+	const data = await getAllArticleByViewsOrLatest({
+		category,
+		sort,
+		cursorId,
+		cursorViews,
+		accessToken,
+	});
 	return data;
 };
 
@@ -104,15 +110,25 @@ export const getAllArticleByViewsOrLatest = async ({
 	return {
 		articles: data.articles,
 		hasNext: data.hasNext,
-		cursorId: String(data.articles[data.articles.length - 1]?.id),
-		cursorViews: String(data.articles[data.articles.length - 1]?.views),
+		cursorId:
+			data.articles && data.articles[data.articles.length - 1]
+				? String(data.articles[data.articles.length - 1].id)
+				: '',
+		cursorViews:
+			data.articles && data.articles[data.articles.length - 1]
+				? String(data.articles[data.articles.length - 1].views)
+				: '',
+		cursorLikes:
+			data.articles && data.articles[data.articles.length - 1]
+				? String(data.articles[data.articles.length - 1].likeCount)
+				: '',
 	};
 };
 
 export const getAllArticlesByLikes = async ({
 	category,
 	cursorId,
-	cursorLikes,
+	cursorLikes = '',
 	accessToken,
 }: {
 	category: string;
@@ -133,8 +149,18 @@ export const getAllArticlesByLikes = async ({
 	return {
 		articles: data.articles,
 		hasNext: data.hasNext,
-		cursorId: String(data.articles[data.articles.length - 1]?.id),
-		cursorLikes: String(data.articles[data.articles.length - 1]?.likeCount),
+		cursorId:
+			data && data.articles[data.articles.length - 1].id
+				? String(data.articles[data.articles.length - 1]?.id)
+				: '',
+		cursorLikes:
+			data && data.articles[data.articles.length - 1].likeCount
+				? String(data.articles[data.articles.length - 1].likeCount)
+				: '',
+		cursorViews:
+			data.articles && data.articles[data.articles.length - 1]
+				? String(data.articles[data.articles.length - 1].views)
+				: '',
 	};
 };
 

--- a/frontend/src/api/article.ts
+++ b/frontend/src/api/article.ts
@@ -150,11 +150,11 @@ export const getAllArticlesByLikes = async ({
 		articles: data.articles,
 		hasNext: data.hasNext,
 		cursorId:
-			data && data.articles[data.articles.length - 1].id
-				? String(data.articles[data.articles.length - 1]?.id)
+			data && data.articles[data.articles.length - 1]
+				? String(data.articles[data.articles.length - 1].id)
 				: '',
 		cursorLikes:
-			data && data.articles[data.articles.length - 1].likeCount
+			data && data.articles[data.articles.length - 1]
 				? String(data.articles[data.articles.length - 1].likeCount)
 				: '',
 		cursorViews:

--- a/frontend/src/hooks/article/useGetCategoryArticles.tsx
+++ b/frontend/src/hooks/article/useGetCategoryArticles.tsx
@@ -21,17 +21,19 @@ const useGetCategoryArticles = (category: string) => {
 				sort: sortIndex,
 				cursorId: '',
 				cursorViews: '',
+				cursorLikes: '',
 			},
 		}) => getAllArticle(pageParam),
 		{
 			getNextPageParam: (lastPage) => {
-				const { hasNext, cursorId, cursorViews } = lastPage;
+				const { hasNext, cursorId, cursorViews, cursorLikes } = lastPage;
 				if (hasNext) {
 					return {
 						category: category,
 						sort: sortIndex,
 						cursorId,
 						cursorViews,
+						cursorLikes,
 					};
 				}
 				return;


### PR DESCRIPTION
Close #636

카테고리 부분에서 nexParam에 cursorLikes들을 넘겨주지 않아 좋아요 순의 조회가 이루어지지 않고 있었고 이를 수정함