### PR TITLE
1009번에 대한 에러 핸들링을 변경한다. 

### DIFF
--- a/frontend/src/utils/confirmErrorType.ts
+++ b/frontend/src/utils/confirmErrorType.ts
@@ -6,7 +6,6 @@ export const isAuthenticatedError = (errorCode: keyof typeof ErrorMessage) =>
 	errorCode === '1003' ||
 	errorCode === '1006' ||
 	errorCode === '1008' ||
-	errorCode === '1009' ||
 	errorCode === '2001';
 
 export const isInValidTokenError = (errorCode: keyof typeof ErrorMessage) =>
@@ -15,7 +14,7 @@ export const isInValidTokenError = (errorCode: keyof typeof ErrorMessage) =>
 export const isExpiredTokenError = (errorCode: keyof typeof ErrorMessage) => errorCode === '1005';
 
 export const isInvalidRefreshTokenError = (errorCode: keyof typeof ErrorMessage) =>
-	errorCode === '1011';
+	errorCode === '1011' || errorCode === '1009';
 
 export const isAlreayLoginRefreshTokenError = (errorCode: keyof typeof ErrorMessage) =>
 	errorCode === '1010';


### PR DESCRIPTION
close #671 

## 구현 사항

1009번 에러에 대하여 `isInvalidRefreshTokenError`로직으로 옮겨서 에러핸들링을 진행하였다.