### PR TITLE
로그아웃하면 디비에서 리프레시 토큰의 변경사항을 반영한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongseek/auth/application/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/auth/application/AuthService.java
@@ -63,7 +63,7 @@ public class AuthService {
             refreshTokenRepository.deleteAll(refreshTokens);
             throw new InvalidRefreshTokenException();
         }
-        refreshToken.used();
+        updateIssue(refreshToken);
 
         RefreshToken newRefreshToken = refreshTokenRepository.save(RefreshToken.create(refreshToken.getMemberId()));
         String accessToken = jwtTokenProvider.createAccessToken(String.valueOf(refreshToken.getMemberId()));
@@ -71,5 +71,16 @@ public class AuthService {
                 .accessToken(accessToken)
                 .refreshToken(newRefreshToken.getId())
                 .build();
+    }
+
+    public void updateRefreshToken(UUID value) {
+        RefreshToken refreshToken = refreshTokenRepository.findById(value)
+                .orElseThrow(InvalidRefreshTokenException::new);
+        updateIssue(refreshToken);
+    }
+
+    private void updateIssue(RefreshToken refreshToken) {
+        refreshToken.used();
+        refreshTokenRepository.save(refreshToken);
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongseek/auth/presentation/AuthController.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/auth/presentation/AuthController.java
@@ -56,7 +56,11 @@ public class AuthController {
     }
 
     @DeleteMapping("/logout")
-    public ResponseEntity<Void> logout(HttpServletResponse httpServletResponse) {
+    public ResponseEntity<Void> logout(
+            @CookieValue(value = "refreshToken", required = false) UUID refreshToken,
+            HttpServletResponse httpServletResponse
+    ) {
+        authService.updateRefreshToken(refreshToken);
         ResponseCookie deleteCookie = CookieUtils.delete();
         httpServletResponse.setHeader(HttpHeaders.SET_COOKIE, deleteCookie.toString());
 

--- a/backend/src/test/java/com/woowacourse/gongseek/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/auth/application/AuthServiceTest.java
@@ -7,6 +7,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.BDDMockito.given;
 
+import com.woowacourse.gongseek.auth.domain.RefreshToken;
+import com.woowacourse.gongseek.auth.domain.repository.RefreshTokenRepository;
 import com.woowacourse.gongseek.auth.exception.InvalidRefreshTokenException;
 import com.woowacourse.gongseek.auth.presentation.dto.GithubProfileResponse;
 import com.woowacourse.gongseek.auth.presentation.dto.OAuthCodeRequest;
@@ -17,6 +19,7 @@ import com.woowacourse.gongseek.member.domain.repository.MemberRepository;
 import com.woowacourse.gongseek.support.DatabaseCleaner;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -36,7 +39,17 @@ class AuthServiceTest {
     private OAuthClient githubOAuthClient;
 
     @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
     private DatabaseCleaner databaseCleaner;
+
+    @BeforeEach
+    void setUp() {
+        GithubProfileResponse profileResponse = new GithubProfileResponse(
+                주디.getGithubId(), 주디.getName(), 주디.getAvatarUrl());
+        given(githubOAuthClient.getMemberProfile(주디.getCode())).willReturn(profileResponse);
+    }
 
     @AfterEach
     void tearDown() {
@@ -52,10 +65,6 @@ class AuthServiceTest {
 
     @Test
     void 엑세스토큰을_발급한다() {
-        GithubProfileResponse profileResponse = new GithubProfileResponse(
-                주디.getGithubId(), 주디.getName(), 주디.getAvatarUrl());
-        given(githubOAuthClient.getMemberProfile(주디.getCode())).willReturn(profileResponse);
-
         TokenResponse response = authService.generateToken(new OAuthCodeRequest(주디.getCode()));
 
         assertThat(response).isNotNull();
@@ -63,9 +72,6 @@ class AuthServiceTest {
 
     @Test
     void 기존_유저의_정보가_바뀌면_로그인을_했을때_업데이트되고_엑세스토큰을_발급한다() {
-        GithubProfileResponse profileResponse = new GithubProfileResponse(
-                주디.getGithubId(), 주디.getName(), 주디.getAvatarUrl());
-        given(githubOAuthClient.getMemberProfile(주디.getCode())).willReturn(profileResponse);
         Member member = new Member(주디.getGithubId(), 주디.getName(), "previous avatar url");
         memberRepository.save(member);
 
@@ -81,22 +87,18 @@ class AuthServiceTest {
     @Test
     void 유저의_이름이_null이면_깃허브_아이디로_대체된다() {
         GithubProfileResponse profileResponse = new GithubProfileResponse(
-                주디.getGithubId(), null, 주디.getAvatarUrl());
-        given(githubOAuthClient.getMemberProfile(주디.getCode())).willReturn(profileResponse);
+                기론.getGithubId(), null, 기론.getAvatarUrl());
+        given(githubOAuthClient.getMemberProfile(기론.getCode())).willReturn(profileResponse);
 
-        authService.generateToken(new OAuthCodeRequest(주디.getCode()));
+        authService.generateToken(new OAuthCodeRequest(기론.getCode()));
 
-        Member actual = memberRepository.findByGithubId(주디.getGithubId()).get();
-        assertThat(actual.getName()).isEqualTo(주디.getGithubId());
+        Member actual = memberRepository.findByGithubId(기론.getGithubId()).get();
+        assertThat(actual.getName()).isEqualTo(기론.getGithubId());
     }
 
     @Test
     void 리프레시토큰이_유효하면_토큰을_재발급한다() {
-        GithubProfileResponse profileResponse = new GithubProfileResponse(
-                기론.getGithubId(), 기론.getName(), 기론.getAvatarUrl());
-        given(githubOAuthClient.getMemberProfile(기론.getCode())).willReturn(profileResponse);
-
-        TokenResponse tokenResponse = authService.generateToken(new OAuthCodeRequest(기론.getCode()));
+        TokenResponse tokenResponse = authService.generateToken(new OAuthCodeRequest(주디.getCode()));
 
         TokenResponse renewToken = authService.renewToken(tokenResponse.getRefreshToken());
         assertAll(
@@ -110,5 +112,17 @@ class AuthServiceTest {
         assertThatThrownBy(() -> authService.renewToken(UUID.randomUUID()))
                 .isExactlyInstanceOf(InvalidRefreshTokenException.class)
                 .hasMessage("리프레시 토큰이 유효하지 않습니다.");
+    }
+
+    @Test
+    void 리프레시토큰의_발급여부를_true로_업데이트한다() {
+        TokenResponse tokenResponse = authService.generateToken(new OAuthCodeRequest(주디.getCode()));
+
+        RefreshToken originRefreshToken = refreshTokenRepository.findById(tokenResponse.getRefreshToken()).get();
+        authService.updateRefreshToken(originRefreshToken.getId());
+        RefreshToken updatedRefreshToken = refreshTokenRepository.findById(originRefreshToken.getId()).get();
+
+        assertThat(originRefreshToken.isIssue()).isFalse();
+        assertThat(updatedRefreshToken.isIssue()).isTrue();
     }
 }


### PR DESCRIPTION
- 로그아웃 로직 수정
- 테스트코드의 중복된 픽스처 BeforeEach로 뺐습니다.

Close #678 