### PR TITLE
jenkins에서 redis 커넥션 정확히 알수 있도록 빈 등록

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongseek/config/EmbeddedRedisConfig.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/config/EmbeddedRedisConfig.java
@@ -9,8 +9,11 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.util.StringUtils;
 import redis.embedded.RedisServer;
 
@@ -21,6 +24,7 @@ public class EmbeddedRedisConfig {
 
     private static final String WINDOW_FIND_PORT_COMMAND = "netstat -nao | find \"LISTEN\" | find \"%d\"";
     private static final String MAC_FIND_PORT_COMMAND = "netstat -nat | grep LISTEN | grep %d";
+    private static final String LOCAL_HOST = "127.0.0.1";
     private static final int MAX_PORT_NUMBER = 65535;
     private static final int MIN_PORT_NUMBER = 10000;
 
@@ -28,6 +32,11 @@ public class EmbeddedRedisConfig {
     private int redisPort;
 
     private RedisServer redisServer;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(LOCAL_HOST, redisPort);
+    }
 
     @PostConstruct
     public void redisServer() {

--- a/backend/src/main/java/com/woowacourse/gongseek/config/EmbeddedRedisConfig.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/config/EmbeddedRedisConfig.java
@@ -18,7 +18,7 @@ import org.springframework.util.StringUtils;
 import redis.embedded.RedisServer;
 
 @Slf4j
-@Profile({"local", "test"})
+@Profile({"local", "test", "invalidToken"})
 @Configuration
 public class EmbeddedRedisConfig {
 

--- a/backend/src/main/java/com/woowacourse/gongseek/config/RedisConfig.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/config/RedisConfig.java
@@ -1,9 +1,11 @@
 package com.woowacourse.gongseek.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
@@ -17,8 +19,14 @@ public class RedisConfig {
     @Value("${spring.redis.port}")
     private int redisPort;
 
+    @Value("${spring.redis.password}")
+    private String password;
+
     @Bean
+    @ConditionalOnMissingBean(RedisConnectionFactory.class)
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(redisHost, redisPort);
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(redisHost, redisPort);
+        configuration.setPassword(password);
+        return new LettuceConnectionFactory(configuration);
     }
 }

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -4,6 +4,7 @@ spring:
   redis:
     host: 127.0.0.1
     port: 6379
+    password: test
   flyway:
     enabled: false
   test:


### PR DESCRIPTION
```Caused by: org.springframework.beans.factory.BeanCreationException at InitDestroyAnnotationBeanPostProcessor.java:160
            Caused by: java.lang.RuntimeException at AbstractRedisInstance.java:62
```
추측상 AbstractRedisInstance 에러가 터지는 걸 봐선 Embedded에 커넥션을 명확히 하지 않아서이지 않을까 생각되어서 수정했습니다.

Close #683 