### PR TITLE
검색결과나 마이페이지 게시글 조회 페이지에서 글이 없을 때에 보여줄 컴포넌트 그리기

### DIFF
--- a/frontend/src/components/common/EmptyMessage/EmptyMessage.styles.tsx
+++ b/frontend/src/components/common/EmptyMessage/EmptyMessage.styles.tsx
@@ -7,11 +7,11 @@ export const Container = styled.section`
 	flex-direction: column;
 
 	width: 100%;
-	height: 80vh;
+	height: 60vh;
 `;
 
 export const EmptyImg = styled.div`
-	size: ${({ theme }) => theme.size.SIZE_040};
+	font-size: ${({ theme }) => theme.size.SIZE_050};
 `;
 
 export const EmptyDescription = styled.div`

--- a/frontend/src/components/common/EmptyMessage/EmptyMessage.styles.tsx
+++ b/frontend/src/components/common/EmptyMessage/EmptyMessage.styles.tsx
@@ -1,0 +1,19 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.section`
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	flex-direction: column;
+
+	width: 100%;
+	height: 80vh;
+`;
+
+export const EmptyImg = styled.div`
+	size: ${({ theme }) => theme.size.SIZE_040};
+`;
+
+export const EmptyDescription = styled.div`
+	margin-top: ${({ theme }) => theme.size.SIZE_020};
+`;

--- a/frontend/src/components/common/EmptyMessage/EmptyMessage.tsx
+++ b/frontend/src/components/common/EmptyMessage/EmptyMessage.tsx
@@ -1,9 +1,9 @@
 import * as S from '@/components/common/EmptyMessage/EmptyMessage.styles';
 
-const EmptyMessage = () => (
+const EmptyMessage = ({ children }: { children: string }) => (
 	<S.Container>
 		<S.EmptyImg>🗑</S.EmptyImg>
-		<S.EmptyDescription>게시글이 텅 비었습니다</S.EmptyDescription>
+		<S.EmptyDescription>{children}</S.EmptyDescription>
 	</S.Container>
 );
 

--- a/frontend/src/components/common/EmptyMessage/EmptyMessage.tsx
+++ b/frontend/src/components/common/EmptyMessage/EmptyMessage.tsx
@@ -1,0 +1,10 @@
+import * as S from '@/components/common/EmptyMessage/EmptyMessage.styles';
+
+const EmptyMessage = () => (
+	<S.Container>
+		<S.EmptyImg>🗑</S.EmptyImg>
+		<S.EmptyDescription>게시글이 텅 비었습니다</S.EmptyDescription>
+	</S.Container>
+);
+
+export default EmptyMessage;

--- a/frontend/src/pages/CategoryArticles/CategoryArticles.styles.tsx
+++ b/frontend/src/pages/CategoryArticles/CategoryArticles.styles.tsx
@@ -57,8 +57,3 @@ export const TitleBox = styled.div`
 	align-items: center;
 	justify-content: space-between;
 `;
-
-export const EmptyText = styled.div`
-	margin: 0 auto;
-	font-size: ${({ theme }) => theme.size.SIZE_024};
-`;

--- a/frontend/src/pages/CategoryArticles/CategoryArticles.tsx
+++ b/frontend/src/pages/CategoryArticles/CategoryArticles.tsx
@@ -1,6 +1,7 @@
 import { useNavigate, useParams } from 'react-router-dom';
 
 import ArticleItem from '@/components/common/ArticleItem/ArticleItem';
+import EmptyMessage from '@/components/common/EmptyMessage/EmptyMessage';
 import InfiniteScrollObserver from '@/components/common/InfiniteScrollObserver/InfiniteScrollObserver';
 import Loading from '@/components/common/Loading/Loading';
 import SortDropdown from '@/components/common/SortDropdown/SortDropDown';
@@ -60,7 +61,7 @@ const CategoryArticles = () => {
 					</S.ArticleItemList>
 				</InfiniteScrollObserver>
 			) : (
-				<S.EmptyText>텅 비었어요..!</S.EmptyText>
+				<EmptyMessage>게시글이 존재하지 않습니다</EmptyMessage>
 			)}
 		</S.Container>
 	);

--- a/frontend/src/pages/HashTagSearch/index.tsx
+++ b/frontend/src/pages/HashTagSearch/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 
+import EmptyMessage from '@/components/common/EmptyMessage/EmptyMessage';
 import useGetAllHashTags from '@/hooks/hashTag/useGetAllHashTags';
 import HashTagSearchBox from '@/pages/HashTagSearch/HashTagSearchBox/HashTagSearchBox';
 import HashTagSearchResult from '@/pages/HashTagSearch/HashTagSearchResult/HashTagSearchResult';
@@ -44,7 +45,7 @@ const HashTagSearch = () => {
 				{selectedHashTags && selectedHashTags.length >= 1 ? (
 					<HashTagSearchResult hashTags={selectedHashTags} />
 				) : (
-					<S.EmptyMsg>해시태그를 눌러주세요</S.EmptyMsg>
+					<EmptyMessage>해시태그를 눌러주세요</EmptyMessage>
 				)}
 			</S.HashTagSearchResultContainer>
 		</S.Container>

--- a/frontend/src/pages/Home/PopularArticle/PopularArticle.styles.tsx
+++ b/frontend/src/pages/Home/PopularArticle/PopularArticle.styles.tsx
@@ -181,8 +181,3 @@ export const CommentIcon = styled(AiOutlineMessage)`
 
 	color: ${({ theme }) => theme.colors.BLACK_600};
 `;
-
-export const EmptyText = styled.div`
-	margin: 0 auto;
-	font-size: ${({ theme }) => theme.size.SIZE_018};
-`;

--- a/frontend/src/pages/Home/PopularArticle/PopularArticle.tsx
+++ b/frontend/src/pages/Home/PopularArticle/PopularArticle.tsx
@@ -1,3 +1,4 @@
+import EmptyMessage from '@/components/common/EmptyMessage/EmptyMessage';
 import Loading from '@/components/common/Loading/Loading';
 import useGetPopularArticles from '@/hooks/article/useGetPopularArticles';
 import ArticleItem from '@/pages/Home/ArticleItem/ArticleItem';
@@ -30,7 +31,7 @@ const PopularArticle = () => {
 	};
 
 	if (!data?.articles.length) {
-		return <S.EmptyText>텅 비었어요..!</S.EmptyText>;
+		return <EmptyMessage>게시글이 존재하지 않습니다</EmptyMessage>;
 	}
 
 	return data ? (

--- a/frontend/src/pages/Home/index.styles.tsx
+++ b/frontend/src/pages/Home/index.styles.tsx
@@ -84,8 +84,3 @@ export const ArticleItemList = styled.div`
 		margin-top: ${({ theme }) => theme.size.SIZE_040};
 	}
 `;
-
-export const EmptyText = styled.div`
-	margin: 0 auto;
-	font-size: ${({ theme }) => theme.size.SIZE_018};
-`;

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import EmptyMessage from '@/components/common/EmptyMessage/EmptyMessage';
 import Loading from '@/components/common/Loading/Loading';
 import SortDropdown from '@/components/common/SortDropdown/SortDropDown';
 import useGetAllArticles from '@/hooks/article/useGetAllArticles';
@@ -67,7 +68,7 @@ const Home = () => {
 						</S.ArticleItemList>
 					</InfiniteScrollObserver>
 				) : (
-					<S.EmptyText>게시물이 존재하지 않습니다</S.EmptyText>
+					<EmptyMessage>게시글이 존재하지 않습니다</EmptyMessage>
 				)}
 			</Suspense>
 		</S.Container>

--- a/frontend/src/pages/MyPage/index.tsx
+++ b/frontend/src/pages/MyPage/index.tsx
@@ -1,3 +1,4 @@
+import EmptyMessage from '@/components/common/EmptyMessage/EmptyMessage';
 import Loading from '@/components/common/Loading/Loading';
 import { URL } from '@/constants/url';
 import useGetUserArticles from '@/hooks/user/useGetUserArticles';
@@ -56,7 +57,7 @@ const MyPage = () => {
 								<UserArticleItem key={article.id} article={article} />
 							))
 						) : (
-							<div>작성하신 글이 없습니다</div>
+							<EmptyMessage>작성하신 글이 없습니다</EmptyMessage>
 						)}
 					</UserItemBox>
 
@@ -66,7 +67,7 @@ const MyPage = () => {
 								<UserCommentBox key={comment.id} comment={comment} />
 							))
 						) : (
-							<div>작성하신 댓글이 없습니다</div>
+							<EmptyMessage>작성하신 댓글이 없습니다</EmptyMessage>
 						)}
 					</UserItemBox>
 				</S.ContentContainer>

--- a/frontend/src/pages/Search/SearchResult/SearchResult.tsx
+++ b/frontend/src/pages/Search/SearchResult/SearchResult.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import ArticleItem from '@/components/common/ArticleItem/ArticleItem';
+import EmptyMessage from '@/components/common/EmptyMessage/EmptyMessage';
 import InfiniteScrollObserver from '@/components/common/InfiniteScrollObserver/InfiniteScrollObserver';
 import Loading from '@/components/common/Loading/Loading';
 import useGetSearch from '@/hooks/search/useGetSearch';
@@ -42,7 +43,7 @@ const SearchResult = ({ target, searchIndex }: { target: string; searchIndex: st
 					</S.SearchResultBox>
 				</InfiniteScrollObserver>
 			) : (
-				<div>검색 결과가 존재하지 않습니다</div>
+				<EmptyMessage>검색 결과가 존재하지 않습니다</EmptyMessage>
 			)}
 		</S.Container>
 	);

--- a/frontend/src/pages/TemporaryArticles/TemporaryArticleList/TemporaryArticleList.styles.tsx
+++ b/frontend/src/pages/TemporaryArticles/TemporaryArticleList/TemporaryArticleList.styles.tsx
@@ -25,5 +25,3 @@ export const ArticleItemBox = styled.div`
 	display: flex;
 	align-items: center;
 `;
-
-export const EmptyArticleMessage = styled.div``;

--- a/frontend/src/pages/TemporaryArticles/TemporaryArticleList/TemporaryArticleList.tsx
+++ b/frontend/src/pages/TemporaryArticles/TemporaryArticleList/TemporaryArticleList.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 
+import EmptyMessage from '@/components/common/EmptyMessage/EmptyMessage';
 import Loading from '@/components/common/Loading/Loading';
 import useDeleteTempArticle from '@/hooks/tempArticle/useDeleteTempArticle';
 import useGetTempArticles from '@/hooks/tempArticle/useGetTempArticles';
@@ -35,7 +36,7 @@ const TemporaryArticleList = () => {
 						</S.ArticleItemBox>
 					))
 				) : (
-					<S.EmptyArticleMessage>임시저장한 글이 존재하지 않습니다</S.EmptyArticleMessage>
+					<EmptyMessage>임시저장한 글이 없습니다</EmptyMessage>
 				)}
 			</S.ArticleListBox>
 		</S.Container>

--- a/frontend/src/storybook/Common/EmptyMessage.stories.tsx
+++ b/frontend/src/storybook/Common/EmptyMessage.stories.tsx
@@ -1,0 +1,18 @@
+import EmptyMessage from '@/components/common/EmptyMessage/EmptyMessage';
+import { Meta, Story } from '@storybook/react';
+
+export default {
+	title: 'Common/EmptyMessage',
+	component: EmptyMessage,
+	decorators: [
+		(Story) => (
+			<div style={{ width: '320px' }}>
+				<Story />
+			</div>
+		),
+	],
+} as Meta;
+
+const Template: Story = () => <EmptyMessage />;
+
+export const DefaultEmptyMEssage = Template.bind({});

--- a/frontend/src/storybook/Common/EmptyMessage.stories.tsx
+++ b/frontend/src/storybook/Common/EmptyMessage.stories.tsx
@@ -13,6 +13,9 @@ export default {
 	],
 } as Meta;
 
-const Template: Story = () => <EmptyMessage />;
+const Template: Story<{ children: string }> = (args) => <EmptyMessage {...args} />;
 
 export const DefaultEmptyMEssage = Template.bind({});
+DefaultEmptyMEssage.args = {
+	children: '빈 게시글 입니다',
+};


### PR DESCRIPTION
close #687 
게시글을 조회하는 곳에서 게시글이 존재하지 않을 경우에 대해서 공통적인 UI 컴포넌트를 보여준다 

![스크린샷 2022-10-03 오후 9 23 33](https://user-images.githubusercontent.com/60773373/193575683-b1aedbd2-722f-481c-b854-7772c0547ef2.png)
*현재 마이페이지가 pr에 올려진 곳에서 수정된 부분이 있어 정확한 UI는 아닐 수 있습니다 

- PropswithStrictChildren 타입을 쓰기에는 {children:string}이라는 표현보다 너무 복잡하게 느껴져서 일단 string으로 타입을 바꿨습니다 