### PR TITLE
임시 게시글 제목 길이가 최대 500자까지 가능하도록 변경

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongseek/article/domain/Title.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/article/domain/Title.java
@@ -17,7 +17,7 @@ public class Title {
     private static final int MIN_TITLE_LENGTH = 1;
     private static final int MAX_TITLE_LENGTH = 500;
 
-    @Column(name = "title", nullable = false)
+    @Column(name = "title", nullable = false, length = MAX_TITLE_LENGTH)
     private String value;
 
     public Title(String value) {

--- a/backend/src/test/java/com/woowacourse/gongseek/article/domain/repository/TempArticleRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/article/domain/repository/TempArticleRepositoryTest.java
@@ -14,6 +14,8 @@ import com.woowacourse.gongseek.support.RepositoryTest;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @RepositoryTest
@@ -41,10 +43,12 @@ class TempArticleRepositoryTest {
                 .build());
     }
 
-    @Test
-    void 임시_게시글을_저장한다() {
+    @ValueSource(strings = {"a", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
+    @ParameterizedTest
+    void 임시_게시글을_저장한다_제목_길이는_최소1에서_최대500자까지_가능하다(String title) {
+        System.out.println(title.length());
         final TempArticle tempArticle = TempArticle.builder()
-                .title(new Title("title"))
+                .title(new Title(title))
                 .content(new Content("content"))
                 .category(Category.QUESTION)
                 .member(member)


### PR DESCRIPTION
## 변경한 부분
- Title 클래스의 value 길이 500으로 변경
- 제목의 최소 길이 ~ 최대 길이를 저장하는 테스트 코드 추가

Close #712 