### PR TITLE
헤더가 보이지 않는 문제를 해결한다. 

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,3 @@
-import usePageChange from './hooks/common/usePageChange';
 import React, { Suspense } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import { useRecoilState, useRecoilValue } from 'recoil';
@@ -11,6 +10,7 @@ import Header from '@/components/@layout/Header/Header';
 import TabBar from '@/components/@layout/TabBar/TabBar';
 import { URL } from '@/constants/url';
 import useHandleHeaderByScroll from '@/hooks/common/useHandleHeaderByScroll';
+import usePageChange from '@/hooks/common/usePageChange';
 import { dropdownState } from '@/store/dropdownState';
 import { menuSliderState } from '@/store/menuSliderState';
 import { getUserIsLogin } from '@/store/userState';

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import usePageChange from './hooks/common/usePageChange';
 import React, { Suspense } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import { useRecoilState, useRecoilValue } from 'recoil';
@@ -9,6 +10,7 @@ import PublicRouter from '@/components/@helper/router/PublicRouter';
 import Header from '@/components/@layout/Header/Header';
 import TabBar from '@/components/@layout/TabBar/TabBar';
 import { URL } from '@/constants/url';
+import useHandleHeaderByScroll from '@/hooks/common/useHandleHeaderByScroll';
 import { dropdownState } from '@/store/dropdownState';
 import { menuSliderState } from '@/store/menuSliderState';
 import { getUserIsLogin } from '@/store/userState';
@@ -91,6 +93,13 @@ const App = () => {
 	const isLogin = useRecoilValue(getUserIsLogin);
 	const [sliderState, setSliderState] = useRecoilState(menuSliderState);
 	const [dropdown, setDropdown] = useRecoilState(dropdownState);
+	const { setIsActiveHeader } = useHandleHeaderByScroll();
+
+	const handleChangePage = () => {
+		setIsActiveHeader(true);
+	};
+
+	usePageChange(handleChangePage);
 
 	return (
 		<Layout

--- a/frontend/src/hooks/common/useHandleHeaderByScroll.tsx
+++ b/frontend/src/hooks/common/useHandleHeaderByScroll.tsx
@@ -10,6 +10,7 @@ const useHandleHeaderByScroll = () => {
 
 	const handleHeaderViewByScroll = () => {
 		const currentScroll = document.documentElement.scrollTop;
+
 		if (!headerElement.current) {
 			return;
 		}
@@ -42,7 +43,7 @@ const useHandleHeaderByScroll = () => {
 		lastScrollTop.current = currentScroll;
 	};
 
-	return { isActiveHeader, handleHeaderViewByScroll, headerElement };
+	return { isActiveHeader, handleHeaderViewByScroll, headerElement, setIsActiveHeader };
 };
 
 export default useHandleHeaderByScroll;

--- a/frontend/src/hooks/common/usePageChange.tsx
+++ b/frontend/src/hooks/common/usePageChange.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const usePageChange = (callback: (...args: unknown[]) => void) => {
+	const location = useLocation();
+
+	useEffect(() => {
+		callback();
+	}, [location]);
+};
+
+export default usePageChange;


### PR DESCRIPTION
close https://github.com/woowacourse-teams/2022-gong-seek/issues/743

문제 원인
헤더가 가려진 상태로 페이지를 이동하게 되면 헤더가 보이지가 않는다. 헤더를 보여지게 하는 로직이 스크롤에 걸려있어서 발생한 문제였다.

해결방법
App.tsx에 페이지가 변할때마다 인지할 수 있는 훅을 이용하여서 페이지가 변경될때마다 헤더가 다시 보일 수 있도록 수정하였다.