### PR TITLE
carousel ui를 변경한다. + 홈페이지의 접근성을 향상한다.

### DIFF
--- a/frontend/src/components/@common/Card/Card.styles.tsx
+++ b/frontend/src/components/@common/Card/Card.styles.tsx
@@ -46,6 +46,7 @@ export const Container = styled.section<{
 		css`
 			transform: scale(0.85);
 			pointer-events: none;
+			opacity: 0.7;
 			filter: blur(2px);
 		`}
 `;

--- a/frontend/src/components/@common/Card/Card.styles.tsx
+++ b/frontend/src/components/@common/Card/Card.styles.tsx
@@ -42,10 +42,10 @@ export const Container = styled.section<{
 			}
 		`} 
 		
-		${({ isActive }) =>
+		${({ isActive, theme }) =>
 		isActive === false &&
 		css`
 			opacity: 0.7;
-			filter: blur(2px) brightness(50%);
+			filter: blur(${theme.size.SIZE_002}) brightness(50%);
 		`}
 `;

--- a/frontend/src/components/@common/Card/Card.styles.tsx
+++ b/frontend/src/components/@common/Card/Card.styles.tsx
@@ -14,8 +14,9 @@ export const Container = styled.section<{
 }>`
 	display: flex;
 	flex-direction: column;
-	transition: all 0.4s cubic-bezier(0.26, 0.71, 1, 0.46);
+	transition: transform 0.3s cubic-bezier(0.26, 0.71, 1, 0.46);
 	position: relative;
+
 	${({ theme }) => css`
 		min-width: ${theme.size.SIZE_200};
 		border-radius: ${theme.size.SIZE_010};
@@ -39,14 +40,13 @@ export const Container = styled.section<{
 				width: ${media.width};
 				height: ${media.height};
 			}
-		`}
-
+		`} 
+		
 		${({ isActive }) =>
 		isActive === false &&
 		css`
-			transform: scale(0.85);
 			pointer-events: none;
 			opacity: 0.7;
-			filter: blur(2px);
+			filter: blur(2px) brightness(50%);
 		`}
 `;

--- a/frontend/src/components/@common/Card/Card.styles.tsx
+++ b/frontend/src/components/@common/Card/Card.styles.tsx
@@ -15,9 +15,9 @@ export const Container = styled.section<{
 	flex-direction: column;
 
 	${({ theme }) => css`
-		min-width: ${theme.size.SIZE_200};
+		// min-width: ${theme.size.SIZE_200};
 		border-radius: ${theme.size.SIZE_010};
-		box-shadow: 0 ${theme.size.SIZE_008} ${theme.size.SIZE_024} ${theme.boxShadows.secondary};
+		box-shadow: 0 ${theme.size.SIZE_006} ${theme.size.SIZE_014} ${theme.boxShadows.secondary};
 	`}
 
 	${({ hasActiveAnimation }) =>

--- a/frontend/src/components/@common/Card/Card.styles.tsx
+++ b/frontend/src/components/@common/Card/Card.styles.tsx
@@ -10,9 +10,11 @@ const scaleAnimation = keyframes`
 export const Container = styled.section<{
 	media: { minWidth: string; width?: string; height?: string } | '';
 	hasActiveAnimation: boolean;
+	isActive?: boolean;
 }>`
 	display: flex;
 	flex-direction: column;
+	transition: all 0.4s cubic-bezier(0.26, 0.71, 1, 0.46);
 
 	${({ theme }) => css`
 		// min-width: ${theme.size.SIZE_200};
@@ -37,5 +39,13 @@ export const Container = styled.section<{
 				width: ${media.width};
 				height: ${media.height};
 			}
+		`}
+
+		${({ isActive }) =>
+		isActive === false &&
+		css`
+			transform: scale(0.85);
+			pointer-events: none;
+			filter: blur(2px);
 		`}
 `;

--- a/frontend/src/components/@common/Card/Card.styles.tsx
+++ b/frontend/src/components/@common/Card/Card.styles.tsx
@@ -45,7 +45,6 @@ export const Container = styled.section<{
 		${({ isActive }) =>
 		isActive === false &&
 		css`
-			pointer-events: none;
 			opacity: 0.7;
 			filter: blur(2px) brightness(50%);
 		`}

--- a/frontend/src/components/@common/Card/Card.styles.tsx
+++ b/frontend/src/components/@common/Card/Card.styles.tsx
@@ -15,9 +15,9 @@ export const Container = styled.section<{
 	display: flex;
 	flex-direction: column;
 	transition: all 0.4s cubic-bezier(0.26, 0.71, 1, 0.46);
-
+	position: relative;
 	${({ theme }) => css`
-		// min-width: ${theme.size.SIZE_200};
+		min-width: ${theme.size.SIZE_200};
 		border-radius: ${theme.size.SIZE_010};
 		box-shadow: 0 ${theme.size.SIZE_006} ${theme.size.SIZE_014} ${theme.boxShadows.secondary};
 	`}

--- a/frontend/src/components/@common/Card/Card.tsx
+++ b/frontend/src/components/@common/Card/Card.tsx
@@ -1,4 +1,4 @@
-import { PropsWithStrictChildren } from 'gongseek-types';
+import { PropsWithOptionalChildren } from 'gongseek-types';
 
 import * as S from '@/components/@common/Card/Card.styles';
 import { CardProps } from '@/types/card';
@@ -10,7 +10,7 @@ const Card = ({
 	hasActiveAnimation,
 	onClick,
 	children,
-}: PropsWithStrictChildren<CardProps>) => (
+}: PropsWithOptionalChildren<CardProps>) => (
 	<S.Container
 		css={css`
 			width: ${cssObject.width};

--- a/frontend/src/components/@common/Card/Card.tsx
+++ b/frontend/src/components/@common/Card/Card.tsx
@@ -18,7 +18,7 @@ const Card = ({
 	const carouselRef = useRef<HTMLElement | null>(null);
 
 	useEffect(() => {
-		if (carouselRef.current) {
+		if (carouselRef.current && isActive !== undefined) {
 			carouselRef.current.inert = !isActive;
 		}
 	}, [carouselRef, isActive]);

--- a/frontend/src/components/@common/Card/Card.tsx
+++ b/frontend/src/components/@common/Card/Card.tsx
@@ -23,6 +23,9 @@ const Card = ({
 			flex-direction: ${cssObject.flexDirection ? cssObject.flexDirection : 'column'};
 			flex-wrap: ${cssObject.flexWrap ? cssObject.flexWrap : 'nowrap'};
 			margin: ${cssObject.margin ? cssObject.margin : 0};
+			flex-shrink: ${cssObject.flexShrink};
+			scroll-snap-align: ${cssObject.scrollSnapAlign};
+			scroll-snap-stop: ${cssObject.scrollSnapStop};
 		`}
 		media={media ? media : ''}
 		hasActiveAnimation={hasActiveAnimation}
@@ -31,4 +34,5 @@ const Card = ({
 		{children}
 	</S.Container>
 );
+
 export default Card;

--- a/frontend/src/components/@common/Card/Card.tsx
+++ b/frontend/src/components/@common/Card/Card.tsx
@@ -14,6 +14,7 @@ const Card = ({
 	children,
 	isActive,
 	role,
+	as,
 }: PropsWithOptionalChildren<CardProps>) => {
 	const carouselRef = useRef<HTMLElement | null>(null);
 
@@ -47,6 +48,7 @@ const Card = ({
 			tabIndex={0}
 			role={role}
 			ref={carouselRef}
+			as={as}
 		>
 			{children}
 		</S.Container>

--- a/frontend/src/components/@common/Card/Card.tsx
+++ b/frontend/src/components/@common/Card/Card.tsx
@@ -10,6 +10,7 @@ const Card = ({
 	hasActiveAnimation,
 	onClick,
 	children,
+	isActive,
 }: PropsWithOptionalChildren<CardProps>) => (
 	<S.Container
 		css={css`
@@ -29,6 +30,7 @@ const Card = ({
 		`}
 		media={media ? media : ''}
 		hasActiveAnimation={hasActiveAnimation}
+		isActive={isActive}
 		onClick={onClick}
 	>
 		{children}

--- a/frontend/src/components/@common/Card/Card.tsx
+++ b/frontend/src/components/@common/Card/Card.tsx
@@ -1,6 +1,5 @@
 import { PropsWithOptionalChildren } from 'gongseek-types';
-import { useRef } from 'react';
-import { useEffect } from 'react';
+import { useRef, useEffect } from 'react';
 
 import * as S from '@/components/@common/Card/Card.styles';
 import { CardProps } from '@/types/card';

--- a/frontend/src/components/@common/Card/Card.tsx
+++ b/frontend/src/components/@common/Card/Card.tsx
@@ -1,4 +1,6 @@
 import { PropsWithOptionalChildren } from 'gongseek-types';
+import { useRef } from 'react';
+import { useEffect } from 'react';
 
 import * as S from '@/components/@common/Card/Card.styles';
 import { CardProps } from '@/types/card';
@@ -11,30 +13,44 @@ const Card = ({
 	onClick,
 	children,
 	isActive,
-}: PropsWithOptionalChildren<CardProps>) => (
-	<S.Container
-		css={css`
-			width: ${cssObject.width};
-			height: ${cssObject.height};
-			padding: ${cssObject.padding ? cssObject.padding : 0};
-			max-width: ${cssObject.maxWidth ? cssObject.maxWidth : cssObject.width};
-			justify-content: ${cssObject.justifyContent ? cssObject.justifyContent : 'normal'};
-			align-items: ${cssObject.alignItems ? cssObject.alignItems : 'normal'};
-			gap: ${cssObject.gap ? cssObject.gap : 0};
-			flex-direction: ${cssObject.flexDirection ? cssObject.flexDirection : 'column'};
-			flex-wrap: ${cssObject.flexWrap ? cssObject.flexWrap : 'nowrap'};
-			margin: ${cssObject.margin ? cssObject.margin : 0};
-			flex-shrink: ${cssObject.flexShrink};
-			scroll-snap-align: ${cssObject.scrollSnapAlign};
-			scroll-snap-stop: ${cssObject.scrollSnapStop};
-		`}
-		media={media ? media : ''}
-		hasActiveAnimation={hasActiveAnimation}
-		isActive={isActive}
-		onClick={onClick}
-	>
-		{children}
-	</S.Container>
-);
+	role,
+}: PropsWithOptionalChildren<CardProps>) => {
+	const carouselRef = useRef<HTMLElement | null>(null);
+
+	useEffect(() => {
+		if (carouselRef.current) {
+			carouselRef.current.inert = !isActive;
+		}
+	}, [carouselRef, isActive]);
+
+	return (
+		<S.Container
+			css={css`
+				width: ${cssObject.width};
+				height: ${cssObject.height};
+				padding: ${cssObject.padding ? cssObject.padding : 0};
+				max-width: ${cssObject.maxWidth ? cssObject.maxWidth : cssObject.width};
+				justify-content: ${cssObject.justifyContent ? cssObject.justifyContent : 'normal'};
+				align-items: ${cssObject.alignItems ? cssObject.alignItems : 'normal'};
+				gap: ${cssObject.gap ? cssObject.gap : 0};
+				flex-direction: ${cssObject.flexDirection ? cssObject.flexDirection : 'column'};
+				margin: ${cssObject.margin ? cssObject.margin : 0};
+				flex-wrap: ${cssObject.flexWrap ? cssObject.flexWrap : 'nowrap'};
+				flex-shrink: ${cssObject.flexShrink};
+				scroll-snap-align: ${cssObject.scrollSnapAlign};
+				scroll-snap-stop: ${cssObject.scrollSnapStop};
+			`}
+			media={media ? media : ''}
+			hasActiveAnimation={hasActiveAnimation}
+			isActive={isActive}
+			onClick={onClick}
+			tabIndex={0}
+			role={role}
+			ref={carouselRef}
+		>
+			{children}
+		</S.Container>
+	);
+};
 
 export default Card;

--- a/frontend/src/components/@common/Dropdown/Dropdown.tsx
+++ b/frontend/src/components/@common/Dropdown/Dropdown.tsx
@@ -32,12 +32,7 @@ const Dropdown = ({ onCloseDropdown }: { onCloseDropdown: () => void }) => {
 	};
 
 	return (
-		<S.Container
-			role="tablist"
-			aria-orientation="vertical"
-			aria-controls="user-dropdown"
-			tabIndex={0}
-		>
+		<S.Container role="tablist" aria-orientation="vertical" tabIndex={0}>
 			<S.DropdownItem
 				onClick={handleClickNavigateMypage}
 				role="tab"

--- a/frontend/src/components/@common/Dropdown/Dropdown.tsx
+++ b/frontend/src/components/@common/Dropdown/Dropdown.tsx
@@ -23,10 +23,41 @@ const Dropdown = ({ onCloseDropdown }: { onCloseDropdown: () => void }) => {
 		}
 	};
 
+	const handleFocusDropdownItem = (e: React.FocusEvent<HTMLDivElement>) => {
+		(e.target as HTMLDivElement).ariaSelected = 'true';
+	};
+
+	const handleBlurDropdownItem = (e: React.FocusEvent<HTMLDivElement>) => {
+		(e.target as HTMLDivElement).ariaSelected = 'false';
+	};
+
 	return (
-		<S.Container>
-			<S.DropdownItem onClick={handleClickNavigateMypage}>마이페이지</S.DropdownItem>
-			<S.DropdownItem onClick={handleClickNavigateLogout}>로그아웃</S.DropdownItem>
+		<S.Container
+			role="tablist"
+			aria-orientation="vertical"
+			aria-controls="user-dropdown"
+			tabIndex={0}
+		>
+			<S.DropdownItem
+				onClick={handleClickNavigateMypage}
+				role="tab"
+				tabIndex={0}
+				onFocus={handleFocusDropdownItem}
+				onBlur={handleBlurDropdownItem}
+				aria-selected="true"
+			>
+				마이페이지
+			</S.DropdownItem>
+			<S.DropdownItem
+				onClick={handleClickNavigateLogout}
+				role="tab"
+				tabIndex={0}
+				onFocus={handleFocusDropdownItem}
+				onBlur={handleBlurDropdownItem}
+				aria-selected="false"
+			>
+				로그아웃
+			</S.DropdownItem>
 		</S.Container>
 	);
 };

--- a/frontend/src/components/@common/ProgressiveBar/ProgressiveBar.styles.tsx
+++ b/frontend/src/components/@common/ProgressiveBar/ProgressiveBar.styles.tsx
@@ -1,0 +1,50 @@
+import { css, keyframes } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const ProgressiveBarAnimation = (percent: number) => keyframes`
+0% {
+  width: 0;
+  background-position: 100% 50%;
+}
+
+50% {
+  background-position: 0% 50%;
+}
+
+100% {
+  width: ${percent}%;
+  background-position: 0% 50%;
+}
+`;
+
+export const ProgressiveBarContainer = styled.div<{
+	width: string;
+	height: string;
+}>`
+	${({ theme, width, height }) => css`
+		width: ${width};
+		height: ${height};
+		border-radius: ${theme.size.SIZE_006};
+
+		background-color: ${theme.colors.GRAY_500};
+
+		margin-left: ${theme.size.SIZE_024};
+	`};
+`;
+
+export const ProgressiveBarContent = styled.div<{
+	percent: number;
+	gradientColor: string;
+	time: number;
+}>`
+	height: 100%;
+	${({ theme, percent, time, gradientColor }) => css`
+		width: ${`${percent}%`};
+
+		border-radius: ${theme.size.SIZE_006};
+
+		background-image: ${gradientColor};
+
+		animation: ${ProgressiveBarAnimation(percent)} ${time}s linear;
+	`}
+`;

--- a/frontend/src/components/@common/ProgressiveBar/ProgressiveBar.tsx
+++ b/frontend/src/components/@common/ProgressiveBar/ProgressiveBar.tsx
@@ -1,0 +1,21 @@
+import * as S from '@/components/@common/ProgressiveBar/ProgressiveBar.styles';
+
+interface ProgressiveBarProps {
+	percent: number;
+	gradientColor: string;
+	time: number;
+	width: string;
+	height: string;
+}
+
+const ProgressiveBar = ({ percent, gradientColor, time, width, height }: ProgressiveBarProps) => (
+	<S.ProgressiveBarContainer width={width} height={height}>
+		<S.ProgressiveBarContent
+			percent={percent}
+			gradientColor={gradientColor}
+			time={time}
+		></S.ProgressiveBarContent>
+	</S.ProgressiveBarContainer>
+);
+
+export default ProgressiveBar;

--- a/frontend/src/components/@common/SortDropdown/SortDropDown.tsx
+++ b/frontend/src/components/@common/SortDropdown/SortDropDown.tsx
@@ -11,7 +11,7 @@ export interface SortPropDownProps {
 
 const SortDropdown = ({ sortList, sortIndex, setSortIndex }: SortPropDownProps) => {
 	const [onDropdown, setOnDropdown] = useState(false);
-	const [isLog, setIsLog] = useState(false);
+	const [isShowAlertLog, setIsShowAlertLog] = useState(false);
 
 	const handleClickSortBox = () => {
 		setOnDropdown((prevOnDropdown) => !prevOnDropdown);
@@ -23,14 +23,14 @@ const SortDropdown = ({ sortList, sortIndex, setSortIndex }: SortPropDownProps) 
 	};
 
 	useEffect(() => {
-		if (isLog) {
-			setIsLog(false);
+		if (isShowAlertLog) {
+			setIsShowAlertLog(false);
 		}
-	}, [isLog]);
+	}, [isShowAlertLog]);
 
 	const handleSortDropdownKeydown = (e: React.KeyboardEvent<HTMLDivElement>) => {
 		if (e.key === 'Escape') {
-			setIsLog(true);
+			setIsShowAlertLog(true);
 			setOnDropdown(false);
 		}
 	};

--- a/frontend/src/components/@common/SortDropdown/SortDropDown.tsx
+++ b/frontend/src/components/@common/SortDropdown/SortDropDown.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import * as S from '@/components/@common/SortDropdown/SortDropdown.styles';
+import { SrOnlyContainer } from '@/components/user/UserProfileIcon/UserProfileIcon.styles';
 
 export interface SortPropDownProps {
 	sortList: string[];
@@ -10,6 +11,7 @@ export interface SortPropDownProps {
 
 const SortDropdown = ({ sortList, sortIndex, setSortIndex }: SortPropDownProps) => {
 	const [onDropdown, setOnDropdown] = useState(false);
+	const [isLog, setIsLog] = useState(false);
 
 	const handleClickSortBox = () => {
 		setOnDropdown((prevOnDropdown) => !prevOnDropdown);
@@ -20,22 +22,46 @@ const SortDropdown = ({ sortList, sortIndex, setSortIndex }: SortPropDownProps) 
 		setOnDropdown(false);
 	};
 
+	useEffect(() => {
+		if (isLog) {
+			setIsLog(false);
+		}
+	}, [isLog]);
+
+	const handleSortDropdownKeydown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+		if (e.key === 'Escape') {
+			setIsLog(true);
+			setOnDropdown(false);
+		}
+	};
+
 	return (
-		<S.Container>
-			<S.SortBox onClick={handleClickSortBox}>
+		<S.Container onKeyDown={handleSortDropdownKeydown}>
+			<S.SortBox
+				onClick={handleClickSortBox}
+				tabIndex={0}
+				aria-label={`게시물 정렬 드롭다운 선택된 상태 ${sortIndex}`}
+			>
 				<div>{sortIndex}</div>
 				<S.ArrowDown />
 			</S.SortBox>
 
 			{onDropdown && (
-				<S.DropdownBox>
+				<S.DropdownBox role="tablist">
 					{sortList.map((sort, idx) => (
-						<S.DropdownItem key={idx} idx={idx} onClick={() => handleClickDropdownItem(sort)}>
+						<S.DropdownItem
+							key={idx}
+							idx={idx}
+							onClick={() => handleClickDropdownItem(sort)}
+							role="tab"
+							tabIndex={0}
+						>
 							{sort}
 						</S.DropdownItem>
 					))}
 				</S.DropdownBox>
 			)}
+			{isLog && <SrOnlyContainer role="alert">닫힘</SrOnlyContainer>}
 		</S.Container>
 	);
 };

--- a/frontend/src/components/@common/SortDropdown/SortDropDown.tsx
+++ b/frontend/src/components/@common/SortDropdown/SortDropDown.tsx
@@ -61,7 +61,7 @@ const SortDropdown = ({ sortList, sortIndex, setSortIndex }: SortPropDownProps) 
 					))}
 				</S.DropdownBox>
 			)}
-			{isLog && <SrOnlyContainer role="alert">닫힘</SrOnlyContainer>}
+			{isShowAlertLog && <SrOnlyContainer role="alert">닫힘</SrOnlyContainer>}
 		</S.Container>
 	);
 };

--- a/frontend/src/components/@layout/Header/Header.tsx
+++ b/frontend/src/components/@layout/Header/Header.tsx
@@ -15,7 +15,7 @@ const Header = () => {
 	const isLogin = useRecoilValue(getUserIsLogin);
 	const { isSearchOpen } = useRecoilValue(searchState);
 	const { handleHeaderViewByScroll, headerElement, isActiveHeader } = useHandleHeaderByScroll();
-	const { ref } = useEnterToClick();
+	const [enterRef] = useEnterToClick();
 
 	useScroll(handleHeaderViewByScroll);
 
@@ -57,7 +57,7 @@ const Header = () => {
 					<S.NavBarItem to={URL.INQUIRE}>문의하기</S.NavBarItem>
 				</S.NavBarItemBox>
 				{isLogin ? (
-					<S.ProfileIconBox ref={ref}>
+					<S.ProfileIconBox ref={enterRef}>
 						<UserProfileIcon />
 					</S.ProfileIconBox>
 				) : (

--- a/frontend/src/components/@layout/Header/Header.tsx
+++ b/frontend/src/components/@layout/Header/Header.tsx
@@ -5,6 +5,7 @@ import * as S from '@/components/@layout/Header/Header.styles';
 import SearchBar from '@/components/search/SearchBar/SearchBar';
 import UserProfileIcon from '@/components/user/UserProfileIcon/UserProfileIcon';
 import { URL } from '@/constants/url';
+import useEnterToClick from '@/hooks/common/useEnterToClick';
 import useHandleHeaderByScroll from '@/hooks/common/useHandleHeaderByScroll';
 import useScroll from '@/hooks/common/useScroll';
 import { searchState } from '@/store/searchState';
@@ -14,6 +15,8 @@ const Header = () => {
 	const isLogin = useRecoilValue(getUserIsLogin);
 	const { isSearchOpen } = useRecoilValue(searchState);
 	const { handleHeaderViewByScroll, headerElement, isActiveHeader } = useHandleHeaderByScroll();
+	const { ref } = useEnterToClick();
+
 	useScroll(handleHeaderViewByScroll);
 
 	if (isSearchOpen) {
@@ -54,7 +57,7 @@ const Header = () => {
 					<S.NavBarItem to={URL.INQUIRE}>문의하기</S.NavBarItem>
 				</S.NavBarItemBox>
 				{isLogin ? (
-					<S.ProfileIconBox>
+					<S.ProfileIconBox ref={ref}>
 						<UserProfileIcon />
 					</S.ProfileIconBox>
 				) : (

--- a/frontend/src/components/@layout/Header/Header.tsx
+++ b/frontend/src/components/@layout/Header/Header.tsx
@@ -43,7 +43,7 @@ const Header = () => {
 					<S.LogoLink>공식</S.LogoLink>
 				</S.StyledLink>
 				<S.SearchBarBox>
-					<S.StyledLink to={URL.SEARCH_RESULT} aria-label="검색하기 페이지로 이동하기">
+					<S.StyledLink to={URL.SEARCH_RESULT} aria-label="엔터를 눌러 검색을 진행하세요">
 						<SearchBar isValid={true} />
 					</S.StyledLink>
 				</S.SearchBarBox>

--- a/frontend/src/components/article/ArticleItem/ArticleItem.styles.tsx
+++ b/frontend/src/components/article/ArticleItem/ArticleItem.styles.tsx
@@ -1,5 +1,6 @@
 import { AiOutlineHeart, AiFillHeart } from 'react-icons/ai';
 
+import { TextOverflow } from '@/styles/mixin';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -14,10 +15,9 @@ export const ArticleItemTitle = styled.h2`
 	white-space: pre-wrap;
 	line-height: 2;
 	word-break: break-all;
-
 	&:hover,
 	&:active {
-		text-decoration: underline;
+		color: ${({ theme }) => theme.colors.BLACK_600};
 	}
 
 	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_LARGE}) {

--- a/frontend/src/components/article/ArticleItem/ArticleItem.styles.tsx
+++ b/frontend/src/components/article/ArticleItem/ArticleItem.styles.tsx
@@ -26,11 +26,19 @@ export const ArticleItemTitle = styled.h2`
 `;
 
 export const Views = styled.div`
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	gap: ${({ theme }) => theme.size.SIZE_006};
 	font-size: ${({ theme }) => theme.size.SIZE_010};
 	font-weight: 400;
 `;
 
 export const CommentCount = styled.div`
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	gap: ${({ theme }) => theme.size.SIZE_006};
 	font-size: ${({ theme }) => theme.size.SIZE_010};
 	font-weight: 400;
 `;
@@ -45,6 +53,7 @@ export const ArticleInfoBox = styled.div`
 
 export const ArticleInfoSubBox = styled.div`
 	display: flex;
+	align-items: center;
 	gap: ${({ theme }) => theme.size.SIZE_010};
 `;
 
@@ -60,7 +69,6 @@ export const UserProfile = styled.img`
 
 export const ProfileBox = styled.div`
 	display: flex;
-	color: white;
 	align-items: center;
 	gap: ${({ theme }) => theme.size.SIZE_012};
 `;

--- a/frontend/src/components/article/ArticleItem/ArticleItem.styles.tsx
+++ b/frontend/src/components/article/ArticleItem/ArticleItem.styles.tsx
@@ -60,7 +60,7 @@ export const UserProfile = styled.img`
 
 export const ProfileBox = styled.div`
 	display: flex;
-
+	color: white;
 	align-items: center;
 	gap: ${({ theme }) => theme.size.SIZE_012};
 `;

--- a/frontend/src/components/article/ArticleItem/ArticleItem.tsx
+++ b/frontend/src/components/article/ArticleItem/ArticleItem.tsx
@@ -68,7 +68,7 @@ const ArticleItem = ({ article, onClick }: ArticleItemProps) => {
 						) : (
 							<S.EmptyHeart onClick={handleClickEmptyHeart} aria-pressed="false" role="button" />
 						)}
-						<div aria-label="좋아요수">{likeCount}</div>
+						<div aria-label={`좋아요수 ${likeCount}`}>{likeCount}</div>
 					</S.HeartBox>
 				</S.RightFooterBox>
 			</S.FooterBox>

--- a/frontend/src/components/article/ArticleItem/ArticleItem.tsx
+++ b/frontend/src/components/article/ArticleItem/ArticleItem.tsx
@@ -32,7 +32,7 @@ const ArticleItem = ({ article, onClick }: ArticleItemProps) => {
 	});
 
 	return (
-		<Card {...ArticleItemCardStyle} onClick={onClick}>
+		<Card {...ArticleItemCardStyle} onClick={onClick} as="li">
 			<S.ArticleItemTitle>
 				<div>{article.title}</div>
 			</S.ArticleItemTitle>

--- a/frontend/src/components/article/ArticleItem/ArticleItem.tsx
+++ b/frontend/src/components/article/ArticleItem/ArticleItem.tsx
@@ -39,28 +39,36 @@ const ArticleItem = ({ article, onClick }: ArticleItemProps) => {
 			<S.ArticleInfoBox>
 				<S.ArticleTimeStamp>{dateTimeConverter(article.createdAt)}</S.ArticleTimeStamp>
 				<S.ArticleInfoSubBox>
-					<S.CommentCount>댓글 수 {article.commentCount}</S.CommentCount>
-					<S.Views>조회 수 {article.views}</S.Views>
+					<S.CommentCount>댓글 수 {article.commentCount.toLocaleString()}</S.CommentCount>
+					<S.Views>조회 수 {article.views.toLocaleString()}</S.Views>
 				</S.ArticleInfoSubBox>
 			</S.ArticleInfoBox>
 			<S.HashTagListBox>
 				{article.tag &&
 					article.tag.length >= 1 &&
-					article.tag.map((item) => <S.HashTagItem key={item}>#{item}</S.HashTagItem>)}
+					article.tag.map((item) => (
+						<S.HashTagItem key={item}>
+							<span aria-label="해시태그">#</span>
+							{item}
+						</S.HashTagItem>
+					))}
 			</S.HashTagListBox>
 			<S.FooterBox>
 				<S.ProfileBox>
-					<S.UserProfile src={convertGithubAvatarUrlForResize(article.author.avatarUrl)} />
+					<S.UserProfile
+						src={convertGithubAvatarUrlForResize(article.author.avatarUrl)}
+						alt="프로필 이미지"
+					/>
 					<div>{article.author.name}</div>
 				</S.ProfileBox>
 				<S.RightFooterBox>
 					<S.HeartBox>
 						{isLike ? (
-							<S.FillHeart onClick={handleClickFillHeart} />
+							<S.FillHeart onClick={handleClickFillHeart} aria-pressed="true" role="button" />
 						) : (
-							<S.EmptyHeart onClick={handleClickEmptyHeart} />
+							<S.EmptyHeart onClick={handleClickEmptyHeart} aria-pressed="false" role="button" />
 						)}
-						<div aria-label="좋아요 수가 표기 되는 곳입니다">{likeCount}</div>
+						<div aria-label="좋아요수">{likeCount}</div>
 					</S.HeartBox>
 				</S.RightFooterBox>
 			</S.FooterBox>

--- a/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
@@ -1,5 +1,6 @@
 import { AiOutlineLeft } from 'react-icons/ai';
 
+import { TextOverflow } from '@/styles/mixin';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -12,11 +13,11 @@ export const Container = styled.section`
 	display: flex;
 
 	align-items: center;
-	width: 90%;
+	width: 85%;
 
 	margin: 0 auto;
-	overflow: hidden;
-	scroll-snap-type: x proximity;
+	overflow: auto;
+	scroll-snap-type: x mandatory;
 
 	&::-webkit-scrollbar {
 		opacity: 0;
@@ -27,7 +28,7 @@ export const Container = styled.section`
 		z-index: ${theme.zIndex.POPULAR_ARTICLES};
 
 		@media (min-width: ${theme.breakpoints.DESKTOP_SMALL}) {
-			width: 60%;
+			width: 75%;
 			height: ${theme.size.SIZE_280};
 		}
 	`}
@@ -102,7 +103,7 @@ export const LeftArrowButton = styled(ArrowButton)`
 	`}
 
 	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_SMALL}) {
-		left: ${({ theme }) => theme.size.SIZE_110};
+		left: ${({ theme }) => theme.size.SIZE_050};
 	}
 `;
 
@@ -112,7 +113,7 @@ export const RightArrowButton = styled(ArrowButton)`
 	`}
 
 	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_SMALL}) {
-		right: ${({ theme }) => theme.size.SIZE_110};
+		right: ${({ theme }) => theme.size.SIZE_050};
 	}
 `;
 
@@ -140,10 +141,7 @@ export const ArticleContent = styled.div`
 
 export const Title = styled.h2`
 	width: 100%;
-	line-height: normal;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	overflow: hidden;
+	${TextOverflow}
 
 	${({ theme }) => css`
 		height: ${theme.size.SIZE_040};

--- a/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
@@ -17,7 +17,6 @@ export const Container = styled.section`
 	margin: 0 auto;
 	overflow: hidden;
 	scroll-snap-type: x proximity;
-	scroll-behavior: smooth;
 
 	&::-webkit-scrollbar {
 		opacity: 0;

--- a/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
@@ -1,4 +1,4 @@
-import { AiOutlineMessage, AiOutlineLeft } from 'react-icons/ai';
+import { AiOutlineMessage, AiOutlineLeft, AiOutlineEye } from 'react-icons/ai';
 
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -93,7 +93,7 @@ export const LeftArrowButton = styled(AiOutlineLeft)`
 	`}
 
 	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_SMALL}) {
-		left: ${({ theme }) => theme.size.SIZE_140};
+		left: ${({ theme }) => theme.size.SIZE_110};
 	}
 `;
 
@@ -119,7 +119,7 @@ export const RightArrowButton = styled(AiOutlineLeft)`
 	`}
 
 	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_SMALL}) {
-		right: ${({ theme }) => theme.size.SIZE_140};
+		right: ${({ theme }) => theme.size.SIZE_110};
 	}
 `;
 
@@ -196,6 +196,12 @@ export const CommentCount = styled.span`
 `;
 
 export const CommentIcon = styled(AiOutlineMessage)`
+	font-size: ${({ theme }) => theme.size.SIZE_016};
+
+	color: ${({ theme }) => theme.colors.BLACK_600};
+`;
+
+export const ViewIcon = styled(AiOutlineEye)`
 	font-size: ${({ theme }) => theme.size.SIZE_016};
 
 	color: ${({ theme }) => theme.colors.BLACK_600};

--- a/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
@@ -13,9 +13,7 @@ export const Container = styled.section`
 
 	align-items: center;
 	width: 90%;
-	height: ${({ theme }) => theme.size.SIZE_280};
 
-	z-index: ${({ theme }) => theme.zIndex.POPULAR_ARTICLES};
 	margin: 0 auto;
 	overflow: hidden;
 	scroll-snap-type: x proximity;
@@ -24,10 +22,16 @@ export const Container = styled.section`
 	&::-webkit-scrollbar {
 		opacity: 0;
 	}
-	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_SMALL}) {
-		width: 60%;
-		height: ${({ theme }) => theme.size.SIZE_280};
-	}
+
+	${({ theme }) => css`
+		height: ${theme.size.SIZE_280};
+		z-index: ${theme.zIndex.POPULAR_ARTICLES};
+
+		@media (min-width: ${theme.breakpoints.DESKTOP_SMALL}) {
+			width: 60%;
+			height: ${theme.size.SIZE_280};
+		}
+	`}
 `;
 
 export const LeftBackgroundArticle = styled.div`

--- a/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
@@ -1,4 +1,4 @@
-import { AiOutlineMessage, AiOutlineLeft, AiOutlineEye } from 'react-icons/ai';
+import { AiOutlineLeft } from 'react-icons/ai';
 
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -191,18 +191,6 @@ export const CommentBox = styled.div`
 
 export const CommentCount = styled.span`
 	font-size: ${({ theme }) => theme.size.SIZE_012};
-
-	color: ${({ theme }) => theme.colors.BLACK_600};
-`;
-
-export const CommentIcon = styled(AiOutlineMessage)`
-	font-size: ${({ theme }) => theme.size.SIZE_016};
-
-	color: ${({ theme }) => theme.colors.BLACK_600};
-`;
-
-export const ViewIcon = styled(AiOutlineEye)`
-	font-size: ${({ theme }) => theme.size.SIZE_016};
 
 	color: ${({ theme }) => theme.colors.BLACK_600};
 `;

--- a/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
@@ -16,12 +16,8 @@ export const Container = styled.section`
 	width: 85%;
 
 	margin: 0 auto;
-	overflow: auto;
+	overflow: hidden;
 	scroll-snap-type: x mandatory;
-
-	&::-webkit-scrollbar {
-		opacity: 0;
-	}
 
 	${({ theme }) => css`
 		height: ${theme.size.SIZE_280};

--- a/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
@@ -11,7 +11,6 @@ export const animationTiming = {
 export const Container = styled.section`
 	display: flex;
 
-	// justify-content: center;
 	align-items: center;
 	width: 90%;
 	height: ${({ theme }) => theme.size.SIZE_280};

--- a/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
@@ -3,15 +3,6 @@ import { AiOutlineLeft } from 'react-icons/ai';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
-export const showPopularSlider = [
-	{
-		transform: 'rotateY(-0.2turn)',
-	},
-	{
-		transform: 'rotateY(0)',
-	},
-];
-
 export const animationTiming = {
 	duration: 500,
 	iterations: 1,
@@ -29,7 +20,6 @@ export const Container = styled.section`
 	margin: 0 auto;
 	overflow: hidden;
 	scroll-snap-type: x proximity;
-	-webkit-overflow-scrolling: touch;
 
 	&::-webkit-scrollbar {
 		opacity: 0;
@@ -136,6 +126,7 @@ export const ArticleContent = styled.div`
 	width: 100%;
 	gap: 1rem;
 	padding: 1rem;
+
 	${({ theme }) => css`
 		border-radius: ${theme.size.SIZE_010};
 

--- a/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
@@ -27,13 +27,12 @@ export const Container = styled.section`
 
 	z-index: ${({ theme }) => theme.zIndex.POPULAR_ARTICLES};
 	margin: 0 auto;
-	overflow: auto;
-	scroll-behavior: smooth;
+	overflow: hidden;
 	scroll-snap-type: x proximity;
 	-webkit-overflow-scrolling: touch;
 
 	&::-webkit-scrollbar {
-		display: none;
+		opacity: 0;
 	}
 	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_SMALL}) {
 		width: 60%;

--- a/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
@@ -20,6 +20,7 @@ export const Container = styled.section`
 	margin: 0 auto;
 	overflow: hidden;
 	scroll-snap-type: x proximity;
+	scroll-behavior: smooth;
 
 	&::-webkit-scrollbar {
 		opacity: 0;

--- a/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
@@ -1,6 +1,5 @@
 import { AiOutlineMessage, AiOutlineLeft } from 'react-icons/ai';
 
-import { articleColors } from '@/styles/Theme';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -31,7 +30,7 @@ export const Container = styled.section`
 	z-index: ${({ theme }) => theme.zIndex.POPULAR_ARTICLES};
 `;
 
-export const LeftBackgroundArticle = styled.div<{ colorKey: keyof typeof articleColors }>`
+export const LeftBackgroundArticle = styled.div`
 	position: absolute;
 
 	top: 0;
@@ -40,15 +39,14 @@ export const LeftBackgroundArticle = styled.div<{ colorKey: keyof typeof article
 	width: 50%;
 	height: 100%;
 
-	${({ theme, colorKey }) => css`
+	${({ theme }) => css`
 		border-radius: ${theme.size.SIZE_010};
-		background-color: ${theme.articleColors[colorKey]};
 
 		z-index: ${theme.zIndex.ARTICLE_BACKGROUND_CONTENT};
 	`}
 `;
 
-export const RightBackgroundArticle = styled.div<{ colorKey: keyof typeof articleColors }>`
+export const RightBackgroundArticle = styled.div`
 	position: absolute;
 
 	top: 0;
@@ -57,9 +55,8 @@ export const RightBackgroundArticle = styled.div<{ colorKey: keyof typeof articl
 	width: 50%;
 	height: 100%;
 
-	${({ theme, colorKey }) => css`
+	${({ theme }) => css`
 		border-radius: ${theme.size.SIZE_010};
-		background-color: ${theme.articleColors[colorKey]};
 
 		z-index: ${theme.zIndex.ARTICLE_BACKGROUND_CONTENT};
 	`}
@@ -108,7 +105,7 @@ export const RightArrowButton = styled(AiOutlineLeft)`
 	`}
 `;
 
-export const ArticleContent = styled.div<{ colorKey: keyof typeof articleColors }>`
+export const ArticleContent = styled.div`
 	display: flex;
 
 	flex-direction: column;
@@ -117,10 +114,8 @@ export const ArticleContent = styled.div<{ colorKey: keyof typeof articleColors 
 	width: 80%;
 	height: 100%;
 
-	${({ theme, colorKey }) => css`
+	${({ theme }) => css`
 		border-radius: ${theme.size.SIZE_010};
-
-		background-color: ${theme.articleColors[colorKey]};
 
 		padding: ${theme.size.SIZE_010};
 		z-index: ${theme.zIndex.ARTICLE_POPULAR_CONTENT};

--- a/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
@@ -128,10 +128,10 @@ export const ArticleContent = styled.div`
 
 	justify-content: space-between;
 	width: 100%;
-	gap: 1rem;
-	padding: 1rem;
 
 	${({ theme }) => css`
+		gap: ${theme.size.SIZE_016};
+		padding: ${theme.size.SIZE_016};
 		border-radius: ${theme.size.SIZE_010};
 
 		padding: ${theme.size.SIZE_010};

--- a/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
@@ -19,15 +19,26 @@ export const animationTiming = {
 
 export const Container = styled.section`
 	display: flex;
-	position: relative;
 
-	justify-content: center;
+	// justify-content: center;
 	align-items: center;
-
-	width: 100%;
-	height: ${({ theme }) => theme.size.SIZE_080};
+	width: 90%;
+	height: ${({ theme }) => theme.size.SIZE_280};
 
 	z-index: ${({ theme }) => theme.zIndex.POPULAR_ARTICLES};
+	margin: 0 auto;
+	overflow: auto;
+	scroll-behavior: smooth;
+	scroll-snap-type: x proximity;
+	-webkit-overflow-scrolling: touch;
+
+	&::-webkit-scrollbar {
+		display: none;
+	}
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_SMALL}) {
+		width: 60%;
+		height: ${({ theme }) => theme.size.SIZE_280};
+	}
 `;
 
 export const LeftBackgroundArticle = styled.div`
@@ -108,12 +119,11 @@ export const RightArrowButton = styled(AiOutlineLeft)`
 export const ArticleContent = styled.div`
 	display: flex;
 
-	flex-direction: column;
 	justify-content: space-between;
-
-	width: 80%;
+	width: 100%;
 	height: 100%;
-
+	gap: 2rem;
+	padding: 1rem;
 	${({ theme }) => css`
 		border-radius: ${theme.size.SIZE_010};
 

--- a/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
@@ -72,11 +72,17 @@ export const RightBackgroundArticle = styled.div`
 	`}
 `;
 
-export const LeftArrowButton = styled(AiOutlineLeft)`
+export const ArrowButton = styled.button`
+	width: ${({ theme }) => theme.size.SIZE_032};
+	height: ${({ theme }) => theme.size.SIZE_032};
+	display: flex;
 	position: absolute;
-	opacity: 0.5;
 
-	cursor: pointer;
+	justify-content: center;
+	align-items: center;
+
+	opacity: 0.5;
+	padding: 0;
 
 	&:hover,
 	&:active {
@@ -84,12 +90,22 @@ export const LeftArrowButton = styled(AiOutlineLeft)`
 	}
 
 	${({ theme }) => css`
-		left: ${theme.size.SIZE_004};
-
 		font-size: ${theme.size.SIZE_020};
-		color: ${theme.colors.BLACK_600};
 
+		color: ${theme.colors.WHITE};
 		z-index: ${theme.zIndex.ARTICLE_ARROW_BUTTON};
+	`}
+
+	border-color: transparent;
+	border-radius: ${({ theme }) => theme.size.SIZE_006};
+	background-color: ${({ theme }) => theme.colors.BLACK_400};
+	background-repeat: no-repeat;
+	cursor: pointer;
+`;
+
+export const LeftArrowButton = styled(ArrowButton)`
+	${({ theme }) => css`
+		left: ${theme.size.SIZE_004};
 	`}
 
 	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_SMALL}) {
@@ -97,30 +113,20 @@ export const LeftArrowButton = styled(AiOutlineLeft)`
 	}
 `;
 
-export const RightArrowButton = styled(AiOutlineLeft)`
-	position: absolute;
-	opacity: 0.5;
-
-	cursor: pointer;
-
-	transform: rotate(180deg);
-
-	&:hover,
-	&:active {
-		opacity: 1;
-	}
+export const RightArrowButton = styled(ArrowButton)`
 	${({ theme }) => css`
 		right: ${theme.size.SIZE_004};
-
-		font-size: ${theme.size.SIZE_020};
-
-		color: ${theme.colors.BLACK_600};
-		z-index: ${theme.zIndex.ARTICLE_ARROW_BUTTON};
 	`}
 
 	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_SMALL}) {
 		right: ${({ theme }) => theme.size.SIZE_110};
 	}
+`;
+
+export const LeftArrowIcon = styled(AiOutlineLeft)``;
+
+export const RightArrowIcon = styled(AiOutlineLeft)`
+	transform: rotate(180deg);
 `;
 
 export const ArticleContent = styled.div`

--- a/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
@@ -84,13 +84,17 @@ export const LeftArrowButton = styled(AiOutlineLeft)`
 	}
 
 	${({ theme }) => css`
-		left: ${theme.size.SIZE_002};
+		left: ${theme.size.SIZE_004};
 
 		font-size: ${theme.size.SIZE_020};
 		color: ${theme.colors.BLACK_600};
 
 		z-index: ${theme.zIndex.ARTICLE_ARROW_BUTTON};
 	`}
+
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_SMALL}) {
+		left: ${({ theme }) => theme.size.SIZE_140};
+	}
 `;
 
 export const RightArrowButton = styled(AiOutlineLeft)`
@@ -106,13 +110,17 @@ export const RightArrowButton = styled(AiOutlineLeft)`
 		opacity: 1;
 	}
 	${({ theme }) => css`
-		right: ${theme.size.SIZE_002};
+		right: ${theme.size.SIZE_004};
 
 		font-size: ${theme.size.SIZE_020};
 
 		color: ${theme.colors.BLACK_600};
 		z-index: ${theme.zIndex.ARTICLE_ARROW_BUTTON};
 	`}
+
+	@media (min-width: ${({ theme }) => theme.breakpoints.DESKTOP_SMALL}) {
+		right: ${({ theme }) => theme.size.SIZE_140};
+	}
 `;
 
 export const ArticleContent = styled.div`
@@ -120,7 +128,6 @@ export const ArticleContent = styled.div`
 
 	justify-content: space-between;
 	width: 100%;
-	height: 100%;
 	gap: 1rem;
 	padding: 1rem;
 	${({ theme }) => css`

--- a/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.styles.tsx
@@ -121,7 +121,7 @@ export const ArticleContent = styled.div`
 	justify-content: space-between;
 	width: 100%;
 	height: 100%;
-	gap: 2rem;
+	gap: 1rem;
 	padding: 1rem;
 	${({ theme }) => css`
 		border-radius: ${theme.size.SIZE_010};

--- a/frontend/src/components/article/PopularArticle/PopularArticle.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.tsx
@@ -27,7 +27,7 @@ const PopularArticle = () => {
 	};
 
 	return data ? (
-		<S.Container ref={handleCarouselElementRef} role="tablist">
+		<S.Container ref={handleCarouselElementRef} role="tablist" aria-labelledby="popular-articles">
 			<S.LeftArrowButton
 				aria-label="이전"
 				aria-disabled={currentIndex === 0}

--- a/frontend/src/components/article/PopularArticle/PopularArticle.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.tsx
@@ -3,12 +3,10 @@ import { Category } from '../../../types/articleResponse';
 import PopularArticleItem from '../PopularArticleItem/PopularArticleItem';
 import { useNavigate } from 'react-router-dom';
 
-import Card from '@/components/@common/Card/Card';
 import EmptyMessage from '@/components/@common/EmptyMessage/EmptyMessage';
 import Loading from '@/components/@common/Loading/Loading';
 import * as S from '@/components/article/PopularArticle/PopularArticle.styles';
 import useGetPopularArticles from '@/hooks/article/useGetPopularArticles';
-import { PopularArticleItemCardStyle } from '@/styles/cardStyle';
 
 const PopularArticle = () => {
 	const { handleCarouselElementRef, handleLeftSlideEvent, handleRightSlideEvent, currentIndex } =
@@ -32,7 +30,7 @@ const PopularArticle = () => {
 		<S.Container ref={handleCarouselElementRef}>
 			<S.LeftArrowButton onClick={handleLeftSlideEvent} />
 			<S.ArticleContent>
-				<Card {...PopularArticleItemCardStyle} isActive={false}></Card>
+				<PopularArticleItem article={data.articles[data.articles.length - 1]} isActive={false} />
 				{data.articles.map((article, idx) => (
 					<PopularArticleItem
 						article={article}
@@ -41,9 +39,10 @@ const PopularArticle = () => {
 						onClick={() =>
 							handleClickArticleItem({ id: String(article.id), category: article.category })
 						}
+						rightSlide={handleRightSlideEvent}
 					/>
 				))}
-				<Card {...PopularArticleItemCardStyle} isActive={false}></Card>
+				<PopularArticleItem article={data.articles[0]} isActive={false} />
 			</S.ArticleContent>
 			<S.RightArrowButton onClick={handleRightSlideEvent} />
 		</S.Container>

--- a/frontend/src/components/article/PopularArticle/PopularArticle.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.tsx
@@ -27,8 +27,8 @@ const PopularArticle = () => {
 	};
 
 	return data ? (
-		<S.Container ref={handleCarouselElementRef}>
-			<S.LeftArrowButton>
+		<S.Container ref={handleCarouselElementRef} role="tablist">
+			<S.LeftArrowButton aria-label="이전" aria-disabled={currentIndex === 0}>
 				<S.LeftArrowIcon onClick={handleLeftSlideEvent} />
 			</S.LeftArrowButton>
 			<S.ArticleContent>
@@ -46,7 +46,7 @@ const PopularArticle = () => {
 				))}
 				<PopularArticleItem article={data.articles[0]} isActive={false} />
 			</S.ArticleContent>
-			<S.RightArrowButton>
+			<S.RightArrowButton aria-label="다음">
 				<S.RightArrowIcon onClick={handleRightSlideEvent} />
 			</S.RightArrowButton>
 		</S.Container>

--- a/frontend/src/components/article/PopularArticle/PopularArticle.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.tsx
@@ -6,13 +6,13 @@ import { useNavigate } from 'react-router-dom';
 import Card from '@/components/@common/Card/Card';
 import EmptyMessage from '@/components/@common/EmptyMessage/EmptyMessage';
 import Loading from '@/components/@common/Loading/Loading';
-import ArticleItem from '@/components/article/ArticleItem/ArticleItem';
 import * as S from '@/components/article/PopularArticle/PopularArticle.styles';
 import useGetPopularArticles from '@/hooks/article/useGetPopularArticles';
 import { PopularArticleItemCardStyle } from '@/styles/cardStyle';
 
 const PopularArticle = () => {
-	const { handleCarouselElementRef, handleLeftSlideEvent, handleRightSlideEvent } = useCarousel();
+	const { handleCarouselElementRef, handleLeftSlideEvent, handleRightSlideEvent, currentIndex } =
+		useCarousel();
 	const { data, isLoading } = useGetPopularArticles();
 	const navigate = useNavigate();
 
@@ -32,11 +32,11 @@ const PopularArticle = () => {
 		<S.Container ref={handleCarouselElementRef}>
 			<S.LeftArrowButton onClick={handleLeftSlideEvent} />
 			<S.ArticleContent>
-				<Card {...PopularArticleItemCardStyle}></Card>
-				{data.articles.map((article) => (
-					<PopularArticleItem article={article} key={article.id} />
+				<Card {...PopularArticleItemCardStyle} isActive={false}></Card>
+				{data.articles.map((article, idx) => (
+					<PopularArticleItem article={article} key={article.id} isActive={currentIndex === idx} />
 				))}
-				<Card {...PopularArticleItemCardStyle}></Card>
+				<Card {...PopularArticleItemCardStyle} isActive={false}></Card>
 			</S.ArticleContent>
 			<S.RightArrowButton onClick={handleRightSlideEvent} />
 		</S.Container>

--- a/frontend/src/components/article/PopularArticle/PopularArticle.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.tsx
@@ -1,15 +1,19 @@
 import useCarousel from '../../../hooks/common/useCarousel';
+import { Category } from '../../../types/articleResponse';
+import PopularArticleItem from '../PopularArticleItem/PopularArticleItem';
+import { useNavigate } from 'react-router-dom';
 
 import EmptyMessage from '@/components/@common/EmptyMessage/EmptyMessage';
 import Loading from '@/components/@common/Loading/Loading';
+import ArticleItem from '@/components/article/ArticleItem/ArticleItem';
 import * as S from '@/components/article/PopularArticle/PopularArticle.styles';
-import PopularArticleItem from '@/components/article/PopularArticleItem/PopularArticleItem';
 import useGetPopularArticles from '@/hooks/article/useGetPopularArticles';
 
 const PopularArticle = () => {
 	const { carouselElement, handleLeftSlideEvent, handleRightSlideEvent, initCarousel } =
 		useCarousel();
 	const { data, isLoading } = useGetPopularArticles(initCarousel);
+	const navigate = useNavigate();
 
 	if (isLoading) {
 		return <Loading />;
@@ -18,6 +22,10 @@ const PopularArticle = () => {
 	if (!data?.articles.length) {
 		return <EmptyMessage>게시글이 존재하지 않습니다</EmptyMessage>;
 	}
+
+	const handleClickArticleItem = ({ id, category }: { id: string; category: Category }) => {
+		navigate(`/articles/${category}/${id}`);
+	};
 
 	return data ? (
 		<S.Container>

--- a/frontend/src/components/article/PopularArticle/PopularArticle.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.tsx
@@ -28,8 +28,12 @@ const PopularArticle = () => {
 
 	return data ? (
 		<S.Container ref={handleCarouselElementRef} role="tablist">
-			<S.LeftArrowButton aria-label="이전" aria-disabled={currentIndex === 0}>
-				<S.LeftArrowIcon onClick={handleLeftSlideEvent} />
+			<S.LeftArrowButton
+				aria-label="이전"
+				aria-disabled={currentIndex === 0}
+				onClick={handleLeftSlideEvent}
+			>
+				<S.LeftArrowIcon />
 			</S.LeftArrowButton>
 			<S.ArticleContent>
 				<PopularArticleItem article={data.articles[data.articles.length - 1]} isActive={false} />
@@ -46,8 +50,8 @@ const PopularArticle = () => {
 				))}
 				<PopularArticleItem article={data.articles[0]} isActive={false} />
 			</S.ArticleContent>
-			<S.RightArrowButton aria-label="다음">
-				<S.RightArrowIcon onClick={handleRightSlideEvent} />
+			<S.RightArrowButton aria-label="다음" onClick={handleRightSlideEvent}>
+				<S.RightArrowIcon />
 			</S.RightArrowButton>
 		</S.Container>
 	) : null;

--- a/frontend/src/components/article/PopularArticle/PopularArticle.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.tsx
@@ -34,7 +34,14 @@ const PopularArticle = () => {
 			<S.ArticleContent>
 				<Card {...PopularArticleItemCardStyle} isActive={false}></Card>
 				{data.articles.map((article, idx) => (
-					<PopularArticleItem article={article} key={article.id} isActive={currentIndex === idx} />
+					<PopularArticleItem
+						article={article}
+						key={article.id}
+						isActive={currentIndex === idx}
+						onClick={() =>
+							handleClickArticleItem({ id: String(article.id), category: article.category })
+						}
+					/>
 				))}
 				<Card {...PopularArticleItemCardStyle} isActive={false}></Card>
 			</S.ArticleContent>

--- a/frontend/src/components/article/PopularArticle/PopularArticle.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.tsx
@@ -1,12 +1,12 @@
-import useCarousel from '../../../hooks/common/useCarousel';
-import { Category } from '../../../types/articleResponse';
-import PopularArticleItem from '../PopularArticleItem/PopularArticleItem';
 import { useNavigate } from 'react-router-dom';
 
 import EmptyMessage from '@/components/@common/EmptyMessage/EmptyMessage';
 import Loading from '@/components/@common/Loading/Loading';
 import * as S from '@/components/article/PopularArticle/PopularArticle.styles';
+import PopularArticleItem from '@/components/article/PopularArticleItem/PopularArticleItem';
 import useGetPopularArticles from '@/hooks/article/useGetPopularArticles';
+import useCarousel from '@/hooks/common/useCarousel';
+import { Category } from '@/types/articleResponse';
 
 const PopularArticle = () => {
 	const { handleCarouselElementRef, handleLeftSlideEvent, handleRightSlideEvent, currentIndex } =

--- a/frontend/src/components/article/PopularArticle/PopularArticle.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.tsx
@@ -1,34 +1,19 @@
+import useCarousel from '../../../hooks/common/useCarousel';
+
 import EmptyMessage from '@/components/@common/EmptyMessage/EmptyMessage';
 import Loading from '@/components/@common/Loading/Loading';
 import * as S from '@/components/article/PopularArticle/PopularArticle.styles';
 import PopularArticleItem from '@/components/article/PopularArticleItem/PopularArticleItem';
 import useGetPopularArticles from '@/hooks/article/useGetPopularArticles';
-import { convertIdxToArticleColorKey } from '@/utils/converter';
 
 const PopularArticle = () => {
-	const {
-		data,
-		isLoading,
-		isIdle,
-		currentIndex,
-		handleClickLeftArrowButton,
-		handleClickRightArrowButton,
-		mainArticleContent,
-	} = useGetPopularArticles();
+	const { carouselElement, handleLeftSlideEvent, handleRightSlideEvent, initCarousel } =
+		useCarousel();
+	const { data, isLoading } = useGetPopularArticles(initCarousel);
 
-	if (isLoading || isIdle) {
+	if (isLoading) {
 		return <Loading />;
 	}
-
-	const getColorKey = (index: number) => {
-		if (index < 0) {
-			return convertIdxToArticleColorKey(9);
-		}
-		if (index > 9) {
-			return convertIdxToArticleColorKey(0);
-		}
-		return convertIdxToArticleColorKey(index);
-	};
 
 	if (!data?.articles.length) {
 		return <EmptyMessage>게시글이 존재하지 않습니다</EmptyMessage>;
@@ -36,13 +21,13 @@ const PopularArticle = () => {
 
 	return data ? (
 		<S.Container>
-			<S.LeftArrowButton onClick={handleClickLeftArrowButton} />
-			<S.LeftBackgroundArticle colorKey={getColorKey(currentIndex - 1)} />
-			<S.ArticleContent colorKey={getColorKey(currentIndex)} ref={mainArticleContent}>
-				<PopularArticleItem article={data.articles[currentIndex]} />
+			<S.LeftArrowButton onClick={handleLeftSlideEvent} />
+			<S.ArticleContent ref={carouselElement}>
+				{data.articles.map((article) => (
+					<PopularArticleItem article={article} key={article.id} />
+				))}
 			</S.ArticleContent>
-			<S.RightBackgroundArticle colorKey={getColorKey(currentIndex + 1)} />
-			<S.RightArrowButton onClick={handleClickRightArrowButton} />
+			<S.RightArrowButton onClick={handleRightSlideEvent} />
 		</S.Container>
 	) : null;
 };

--- a/frontend/src/components/article/PopularArticle/PopularArticle.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.tsx
@@ -28,7 +28,9 @@ const PopularArticle = () => {
 
 	return data ? (
 		<S.Container ref={handleCarouselElementRef}>
-			<S.LeftArrowButton onClick={handleLeftSlideEvent} />
+			<S.LeftArrowButton>
+				<S.LeftArrowIcon onClick={handleLeftSlideEvent} />
+			</S.LeftArrowButton>
 			<S.ArticleContent>
 				<PopularArticleItem article={data.articles[data.articles.length - 1]} isActive={false} />
 				{data.articles.map((article, idx) => (
@@ -44,7 +46,9 @@ const PopularArticle = () => {
 				))}
 				<PopularArticleItem article={data.articles[0]} isActive={false} />
 			</S.ArticleContent>
-			<S.RightArrowButton onClick={handleRightSlideEvent} />
+			<S.RightArrowButton>
+				<S.RightArrowIcon onClick={handleRightSlideEvent} />
+			</S.RightArrowButton>
 		</S.Container>
 	) : null;
 };

--- a/frontend/src/components/article/PopularArticle/PopularArticle.tsx
+++ b/frontend/src/components/article/PopularArticle/PopularArticle.tsx
@@ -3,16 +3,17 @@ import { Category } from '../../../types/articleResponse';
 import PopularArticleItem from '../PopularArticleItem/PopularArticleItem';
 import { useNavigate } from 'react-router-dom';
 
+import Card from '@/components/@common/Card/Card';
 import EmptyMessage from '@/components/@common/EmptyMessage/EmptyMessage';
 import Loading from '@/components/@common/Loading/Loading';
 import ArticleItem from '@/components/article/ArticleItem/ArticleItem';
 import * as S from '@/components/article/PopularArticle/PopularArticle.styles';
 import useGetPopularArticles from '@/hooks/article/useGetPopularArticles';
+import { PopularArticleItemCardStyle } from '@/styles/cardStyle';
 
 const PopularArticle = () => {
-	const { carouselElement, handleLeftSlideEvent, handleRightSlideEvent, initCarousel } =
-		useCarousel();
-	const { data, isLoading } = useGetPopularArticles(initCarousel);
+	const { handleCarouselElementRef, handleLeftSlideEvent, handleRightSlideEvent } = useCarousel();
+	const { data, isLoading } = useGetPopularArticles();
 	const navigate = useNavigate();
 
 	if (isLoading) {
@@ -28,12 +29,14 @@ const PopularArticle = () => {
 	};
 
 	return data ? (
-		<S.Container>
+		<S.Container ref={handleCarouselElementRef}>
 			<S.LeftArrowButton onClick={handleLeftSlideEvent} />
-			<S.ArticleContent ref={carouselElement}>
+			<S.ArticleContent>
+				<Card {...PopularArticleItemCardStyle}></Card>
 				{data.articles.map((article) => (
 					<PopularArticleItem article={article} key={article.id} />
 				))}
+				<Card {...PopularArticleItemCardStyle}></Card>
 			</S.ArticleContent>
 			<S.RightArrowButton onClick={handleRightSlideEvent} />
 		</S.Container>

--- a/frontend/src/components/article/PopularArticleItem/PopularArticleItem.styles.tsx
+++ b/frontend/src/components/article/PopularArticleItem/PopularArticleItem.styles.tsx
@@ -1,137 +1,39 @@
-import { AiOutlineHeart, AiOutlineMessage } from 'react-icons/ai';
+import { AiOutlineEye, AiOutlineMessage, AiFillHeart } from 'react-icons/ai';
 
-import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
-export const ArticleContent = styled.div`
-	display: flex;
-
-	flex-direction: column;
-	justify-content: space-between;
-
-	width: 80%;
-	height: 100%;
-
-	${({ theme }) => css`
-		border-radius: ${theme.size.SIZE_010};
-		padding: ${theme.size.SIZE_010};
-
-		z-index: ${theme.zIndex.ARTICLE_POPULAR_CONTENT};
-	`}
-`;
-
-export const Title = styled.h2`
-	width: 100%;
-
-	line-height: normal;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	overflow: hidden;
-
-	${({ theme }) => css`
-		height: ${theme.size.SIZE_040};
-
-		font-size: ${theme.size.SIZE_014};
-		margin-top: ${theme.size.SIZE_004};
-	`}
-`;
-
-export const ArticleInfo = styled.div`
-	display: flex;
-
-	justify-content: space-between;
-`;
-
-export const ProfileBox = styled.div`
-	display: flex;
-
-	align-items: center;
-	gap: ${({ theme }) => theme.size.SIZE_006};
-`;
-
-export const UserImg = styled.img`
-	width: ${({ theme }) => theme.size.SIZE_024};
-	height: ${({ theme }) => theme.size.SIZE_024};
-
-	border-radius: 50%;
-
-	object-fit: cover;
-	object-position: center;
-`;
-
-export const UserName = styled.span`
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: normal;
-
-	${({ theme }) => css`
-		width: ${theme.size.SIZE_100};
-		font-size: ${theme.size.SIZE_012};
-
-		color: ${theme.colors.BLACK_600};
-	`}
-`;
-
-export const SubInfoBox = styled.div`
-	display: flex;
-	margin-top: ${({ theme }) => theme.size.SIZE_004};
-
-	gap: ${({ theme }) => theme.size.SIZE_010};
-`;
-
-export const ViewsBox = styled.div`
-	display: flex;
-
-	align-items: center;
-	gap: ${({ theme }) => theme.size.SIZE_006};
-`;
-
-export const ViewsIcon = styled.div`
-	font-size: ${({ theme }) => theme.size.SIZE_012};
-
-	color: ${({ theme }) => theme.colors.BLACK_600};
-`;
-
-export const ViewsCount = styled.div`
-	font-size: ${({ theme }) => theme.size.SIZE_012};
-
-	color: ${({ theme }) => theme.colors.BLACK_600};
-`;
-
-export const LikeBox = styled.div`
-	display: flex;
-
-	align-items: center;
-	gap: ${({ theme }) => theme.size.SIZE_006};
-`;
-
-export const LikeIcon = styled(AiOutlineHeart)`
-	font-size: ${({ theme }) => theme.size.SIZE_016};
-
-	color: ${({ theme }) => theme.colors.BLACK_600};
-`;
-
-export const LikeCount = styled.div`
-	font-size: ${({ theme }) => theme.size.SIZE_012};
-
-	color: ${({ theme }) => theme.colors.BLACK_600};
-`;
-
-export const CommentBox = styled.div`
-	display: flex;
-
-	align-items: center;
-	gap: ${({ theme }) => theme.size.SIZE_006};
-`;
-
-export const CommentCount = styled.span`
-	font-size: ${({ theme }) => theme.size.SIZE_012};
-
-	color: ${({ theme }) => theme.colors.BLACK_600};
+export const CategoryBox = styled.div<{ categoryType: 'question' | 'discussion' }>`
+	background-color: white;
+	border-radius: ${({ theme }) => theme.size.SIZE_006};
+	color: ${({ categoryType, theme }) =>
+		categoryType === 'question' ? theme.colors.RED_500 : theme.colors.BLUE_500};
+	padding: 0.5rem;
+	margin-left: auto;
 `;
 
 export const CommentIcon = styled(AiOutlineMessage)`
 	font-size: ${({ theme }) => theme.size.SIZE_016};
 
 	color: ${({ theme }) => theme.colors.BLACK_600};
+`;
+
+export const ViewIcon = styled(AiOutlineEye)`
+	font-size: ${({ theme }) => theme.size.SIZE_016};
+
+	color: ${({ theme }) => theme.colors.BLACK_600};
+`;
+
+export const HeartIcon = styled(AiFillHeart)`
+	font-size: ${({ theme }) => theme.size.SIZE_016};
+
+	color: ${({ theme }) => theme.colors.RED_600};
+`;
+
+export const IconContainer = styled.div`
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	gap: ${({ theme }) => theme.size.SIZE_006};
+	font-size: ${({ theme }) => theme.size.SIZE_010};
+	font-weight: 400;
 `;

--- a/frontend/src/components/article/PopularArticleItem/PopularArticleItem.styles.tsx
+++ b/frontend/src/components/article/PopularArticleItem/PopularArticleItem.styles.tsx
@@ -5,6 +5,7 @@ import {
 	ArticleItemTitle,
 	HashTagListBox,
 } from '@/components/article/ArticleItem/ArticleItem.styles';
+import { TextOverflow } from '@/styles/mixin';
 import { Category } from '@/types/articleResponse';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -62,11 +63,14 @@ export const PopularArticleHeader = styled.div<{ category: Category }>`
 		background: ${category === 'question' ? theme.colors.RED_500 : theme.colors.BLUE_500};
 		opacity: 0.8;
 		box-shadow: 0, 0, 0, inset 0 0 4px #5e0080;
-		padding: ${theme.size.SIZE_012};
+		padding: ${theme.size.SIZE_014} ${theme.size.SIZE_012};
 		border-top-left-radius: ${theme.size.SIZE_010};
 		border-top-right-radius: ${theme.size.SIZE_010};
-		margin-bottom: ${theme.size.SIZE_016};
+		margin-bottom: ${theme.size.SIZE_006};
+		line-height: ${theme.size.SIZE_024};
 	`}
+
+	${TextOverflow}
 `;
 
 export const PopularArticleContent = styled.div`
@@ -79,5 +83,8 @@ export const PopularArticleHashTagListBox = styled(HashTagListBox)`
 `;
 
 export const PopularArticleItemTitle = styled(ArticleItemTitle)`
-	height: inherit;
+	display: flex;
+	height: ${({ theme }) => theme.size.SIZE_038};
+
+	${TextOverflow}
 `;

--- a/frontend/src/components/article/PopularArticleItem/PopularArticleItem.styles.tsx
+++ b/frontend/src/components/article/PopularArticleItem/PopularArticleItem.styles.tsx
@@ -11,11 +11,12 @@ import styled from '@emotion/styled';
 
 export const CategoryBox = styled.div<{ categoryType: 'question' | 'discussion' }>`
 	background-color: white;
-	border-radius: ${({ theme }) => theme.size.SIZE_006};
-	color: ${({ categoryType, theme }) =>
-		categoryType === 'question' ? theme.colors.RED_500 : theme.colors.BLUE_500};
-	padding: 0.5rem;
 	margin-left: auto;
+	${({ theme, categoryType }) => css`
+		border-radius: ${theme.size.SIZE_006};
+		color: ${categoryType === 'question' ? theme.colors.RED_500 : theme.colors.BLUE_500};
+		padding: ${theme.size.SIZE_008};
+	`}
 `;
 
 export const CommentIcon = styled(AiOutlineMessage)`
@@ -65,7 +66,7 @@ export const PopularArticleHeader = styled.div<{ category: Category }>`
 		padding: ${theme.size.SIZE_012};
 		border-top-left-radius: ${theme.size.SIZE_010};
 		border-top-right-radius: ${theme.size.SIZE_010};
-		margin-bottom: 1rem;
+		margin-bottom: ${theme.size.SIZE_016};
 	`}
 `;
 
@@ -74,7 +75,7 @@ export const PopularArticleContent = styled.div`
 `;
 
 export const PopularArticleHashTagListBox = styled(HashTagListBox)`
-	margin: 1rem 0;
+	margin: ${({ theme }) => theme.size.SIZE_016} 0;
 	height: inherit;
 `;
 

--- a/frontend/src/components/article/PopularArticleItem/PopularArticleItem.styles.tsx
+++ b/frontend/src/components/article/PopularArticleItem/PopularArticleItem.styles.tsx
@@ -1,5 +1,12 @@
 import { AiOutlineEye, AiOutlineMessage, AiFillHeart } from 'react-icons/ai';
 
+import {
+	UserProfile,
+	ArticleItemTitle,
+	HashTagListBox,
+} from '@/components/article/ArticleItem/ArticleItem.styles';
+import { Category } from '@/types/articleResponse';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 export const CategoryBox = styled.div<{ categoryType: 'question' | 'discussion' }>`
@@ -36,4 +43,41 @@ export const IconContainer = styled.div`
 	gap: ${({ theme }) => theme.size.SIZE_006};
 	font-size: ${({ theme }) => theme.size.SIZE_010};
 	font-weight: 400;
+`;
+
+export const AuthorNameText = styled.div`
+	color: white;
+`;
+
+export const PopularArticleUserProfile = styled(UserProfile)`
+	border: 2px solid transparent;
+	background-image: linear-gradient(to bottom, #ffffcc 7%, #ff9900 96%),
+		linear-gradient(to bottom, #ff3300 7%, #66ffcc 96%);
+	background-origin: border-box;
+	background-clip: content-box, border-box;
+`;
+
+export const PopularArticleHeader = styled.div<{ category: Category }>`
+	${({ theme, category }) => css`
+		background: ${category === 'question' ? theme.colors.RED_500 : theme.colors.BLUE_500};
+		opacity: 0.8;
+		box-shadow: 0, 0, 0, inset 0 0 4px #5e0080;
+		padding: ${theme.size.SIZE_012};
+		border-top-left-radius: ${theme.size.SIZE_010};
+		border-top-right-radius: ${theme.size.SIZE_010};
+		margin-bottom: 1rem;
+	`}
+`;
+
+export const PopularArticleContent = styled.div`
+	padding: ${({ theme }) => theme.size.SIZE_014};
+`;
+
+export const PopularArticleHashTagListBox = styled(HashTagListBox)`
+	margin: 1rem 0;
+	height: inherit;
+`;
+
+export const PopularArticleItemTitle = styled(ArticleItemTitle)`
+	height: inherit;
 `;

--- a/frontend/src/components/article/PopularArticleItem/PopularArticleItem.styles.tsx
+++ b/frontend/src/components/article/PopularArticleItem/PopularArticleItem.styles.tsx
@@ -52,8 +52,7 @@ export const AuthorNameText = styled.div`
 
 export const PopularArticleUserProfile = styled(UserProfile)`
 	border: 2px solid transparent;
-	background-image: linear-gradient(to bottom, #ffffcc 7%, #ff9900 96%),
-		linear-gradient(to bottom, #ff3300 7%, #66ffcc 96%);
+	background-image: ${({ theme }) => theme.GradientColors.POPULAR_PROFILE_BORDER};
 	background-origin: border-box;
 	background-clip: content-box, border-box;
 `;

--- a/frontend/src/components/article/PopularArticleItem/PopularArticleItem.styles.tsx
+++ b/frontend/src/components/article/PopularArticleItem/PopularArticleItem.styles.tsx
@@ -26,7 +26,6 @@ export const Title = styled.h2`
 	line-height: normal;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	overflow: hidden;
 
 	${({ theme }) => css`
 		height: ${theme.size.SIZE_040};

--- a/frontend/src/components/article/PopularArticleItem/PopularArticleItem.styles.tsx
+++ b/frontend/src/components/article/PopularArticleItem/PopularArticleItem.styles.tsx
@@ -26,6 +26,7 @@ export const Title = styled.h2`
 	line-height: normal;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	overflow: hidden;
 
 	${({ theme }) => css`
 		height: ${theme.size.SIZE_040};

--- a/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
+++ b/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
@@ -1,8 +1,10 @@
 import { useNavigate } from 'react-router-dom';
 
-import * as S from '@/components/article/PopularArticleItem/PopularArticleItem.styles';
+import Card from '@/components/@common/Card/Card';
+import * as S from '@/components/article/ArticleItem/ArticleItem.styles';
+import { PopularArticleItemCardStyle } from '@/styles/cardStyle';
 import { CommonArticleType } from '@/types/articleResponse';
-import { convertGithubAvatarUrlForResize } from '@/utils/converter';
+import { convertGithubAvatarUrlForResize, dateTimeConverter } from '@/utils/converter';
 
 const PopularArticleItem = ({ article }: { article: CommonArticleType }) => {
 	const navigate = useNavigate();
@@ -13,32 +15,30 @@ const PopularArticleItem = ({ article }: { article: CommonArticleType }) => {
 	};
 	return (
 		<>
-			<S.Title onClick={handleClickTitle}>{title}</S.Title>
-			<S.ArticleInfo>
-				<S.ProfileBox>
-					<S.UserImg
-						alt="유저의 프로필 이미지가 보여지는 곳 입니다 "
-						src={convertGithubAvatarUrlForResize(author.avatarUrl)}
-					/>
-					<S.UserName>{author.name}</S.UserName>
-				</S.ProfileBox>
-				<S.SubInfoBox>
-					<S.ViewsBox>
-						<S.ViewsIcon>조회수</S.ViewsIcon>
-						<S.ViewsCount aria-label="조회수가 표시되는 곳입니다">{views}</S.ViewsCount>
-					</S.ViewsBox>
-					<S.LikeBox>
-						<S.LikeIcon />
-						<S.LikeCount aria-label="좋아요 수가 표시되는 곳입니다">{likeCount}</S.LikeCount>
-					</S.LikeBox>
-					<S.CommentBox>
-						<S.CommentIcon />
-						<S.CommentCount aria-label="댓글의 개수가 표시되는 곳입니다">
-							{commentCount}
-						</S.CommentCount>
-					</S.CommentBox>
-				</S.SubInfoBox>
-			</S.ArticleInfo>
+			<Card {...PopularArticleItemCardStyle}>
+				<S.ArticleItemTitle>
+					<div>{article.title}</div>
+				</S.ArticleItemTitle>
+				<S.ArticleInfoBox>
+					<S.ArticleTimeStamp>{dateTimeConverter(article.createdAt)}</S.ArticleTimeStamp>
+					<S.ArticleInfoSubBox>
+						<S.CommentCount>댓글 수 {article.commentCount}</S.CommentCount>
+						<S.Views>조회 수 {article.views}</S.Views>
+					</S.ArticleInfoSubBox>
+				</S.ArticleInfoBox>
+				<S.HashTagListBox>
+					{article.tag &&
+						article.tag.length >= 1 &&
+						article.tag.map((item) => <S.HashTagItem key={item}>#{item}</S.HashTagItem>)}
+				</S.HashTagListBox>
+				<S.FooterBox>
+					<S.ProfileBox>
+						<S.UserProfile src={convertGithubAvatarUrlForResize(article.author.avatarUrl)} />
+						<div>{article.author.name}</div>
+					</S.ProfileBox>
+					<S.RightFooterBox></S.RightFooterBox>
+				</S.FooterBox>
+			</Card>
 		</>
 	);
 };

--- a/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
+++ b/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
@@ -6,7 +6,13 @@ import { PopularArticleItemCardStyle } from '@/styles/cardStyle';
 import { CommonArticleType } from '@/types/articleResponse';
 import { convertGithubAvatarUrlForResize, dateTimeConverter } from '@/utils/converter';
 
-const PopularArticleItem = ({ article }: { article: CommonArticleType }) => {
+const PopularArticleItem = ({
+	article,
+	isActive,
+}: {
+	article: CommonArticleType;
+	isActive: boolean;
+}) => {
 	const navigate = useNavigate();
 	const { id, title, author, commentCount, views, likeCount, category } = article;
 
@@ -15,7 +21,7 @@ const PopularArticleItem = ({ article }: { article: CommonArticleType }) => {
 	};
 	return (
 		<>
-			<Card {...PopularArticleItemCardStyle}>
+			<Card {...PopularArticleItemCardStyle} isActive={isActive}>
 				<S.ArticleItemTitle>
 					<div>{article.title}</div>
 				</S.ArticleItemTitle>

--- a/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
+++ b/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 
 import Card from '@/components/@common/Card/Card';
 import * as S from '@/components/article/ArticleItem/ArticleItem.styles';
-import * as PopularS from '@/components/article/PopularArticle/PopularArticle.styles';
+import * as PopularS from '@/components/article/PopularArticleItem/PopularArticleItem.styles';
 import { theme } from '@/styles/Theme';
 import { PopularArticleItemCardStyle } from '@/styles/cardStyle';
 import { CommonArticleType } from '@/types/articleResponse';
@@ -20,8 +20,10 @@ const PopularArticleItem = ({
 	onClick?: () => void;
 	rightSlide?: () => void;
 }) => {
-	const { title, author, commentCount, views, createdAt, tag } = article;
+	const { title, author, commentCount, views, createdAt, tag, category, likeCount } = article;
 	const timerId = useRef<number | undefined>(undefined);
+	const 한글_카테고리 = category === 'question' ? '질문' : '토론';
+
 	useEffect(() => {
 		if (isActive && rightSlide) {
 			timerId.current = window.setTimeout(rightSlide, 5000);
@@ -64,6 +66,7 @@ const PopularArticleItem = ({
 						>
 							{author.name}
 						</div>
+						<PopularS.CategoryBox categoryType={category}>{한글_카테고리}</PopularS.CategoryBox>
 					</S.ProfileBox>
 				</div>
 				<div
@@ -81,13 +84,17 @@ const PopularArticleItem = ({
 					<S.ArticleInfoBox>
 						<S.ArticleTimeStamp>{dateTimeConverter(createdAt)}</S.ArticleTimeStamp>
 						<S.ArticleInfoSubBox>
-							<S.CommentCount>
+							<PopularS.IconContainer>
 								<PopularS.CommentIcon />
 								{commentCount}
-							</S.CommentCount>
-							<S.Views>
+							</PopularS.IconContainer>
+							<PopularS.IconContainer>
 								<PopularS.ViewIcon /> {views}
-							</S.Views>
+							</PopularS.IconContainer>
+							<PopularS.IconContainer>
+								<PopularS.HeartIcon />
+								{likeCount}
+							</PopularS.IconContainer>
 						</S.ArticleInfoSubBox>
 					</S.ArticleInfoBox>
 

--- a/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
+++ b/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
@@ -1,3 +1,4 @@
+import { CAROUSEL_AUTO_PLAY_TIME } from '../../../constants/index';
 import { useEffect, useRef } from 'react';
 
 import Card from '@/components/@common/Card/Card';
@@ -26,7 +27,7 @@ const PopularArticleItem = ({
 
 	useEffect(() => {
 		if (isActive && rightSlide) {
-			timerId.current = window.setTimeout(rightSlide, 3000);
+			timerId.current = window.setTimeout(rightSlide, CAROUSEL_AUTO_PLAY_TIME);
 		}
 
 		return () => {

--- a/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
+++ b/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
@@ -37,7 +37,7 @@ const PopularArticleItem = ({
 
 	return (
 		<>
-			<Card {...PopularArticleItemCardStyle} isActive={isActive} onClick={onClick}>
+			<Card {...PopularArticleItemCardStyle} isActive={isActive} onClick={onClick} role="link">
 				<div
 					css={css`
 						background: #ba55d3;
@@ -52,6 +52,7 @@ const PopularArticleItem = ({
 					<S.ProfileBox>
 						<S.UserProfile
 							src={convertGithubAvatarUrlForResize(author.avatarUrl)}
+							alt="프로필 이미지"
 							css={css`
 								border: 2px solid transparent;
 								background-image: linear-gradient(to bottom, #ffffcc 7%, #ff9900 96%),
@@ -86,15 +87,16 @@ const PopularArticleItem = ({
 						<S.ArticleTimeStamp>{dateTimeConverter(createdAt)}</S.ArticleTimeStamp>
 						<S.ArticleInfoSubBox>
 							<PopularS.IconContainer>
-								<PopularS.CommentIcon />
-								{commentCount}
+								<PopularS.CommentIcon aria-label="댓글수" />
+								{commentCount.toLocaleString()}
 							</PopularS.IconContainer>
 							<PopularS.IconContainer>
-								<PopularS.ViewIcon /> {views}
+								<PopularS.ViewIcon aria-label="조회수" />
+								{views.toLocaleString()}
 							</PopularS.IconContainer>
 							<PopularS.IconContainer>
-								<PopularS.HeartIcon />
-								{likeCount}
+								<PopularS.HeartIcon aria-label="좋아요수" />
+								{likeCount.toLocaleString()}
 							</PopularS.IconContainer>
 						</S.ArticleInfoSubBox>
 					</S.ArticleInfoBox>
@@ -107,7 +109,12 @@ const PopularArticleItem = ({
 					>
 						{tag &&
 							tag.length >= 1 &&
-							tag.map((item) => <S.HashTagItem key={item}>#{item}</S.HashTagItem>)}
+							tag.map((item) => (
+								<S.HashTagItem key={item}>
+									<span aria-label="해시태그">#</span>
+									{item}
+								</S.HashTagItem>
+							))}
 					</S.HashTagListBox>
 				</div>
 			</Card>

--- a/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
+++ b/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
@@ -1,49 +1,75 @@
-import { useNavigate } from 'react-router-dom';
-
 import Card from '@/components/@common/Card/Card';
 import * as S from '@/components/article/ArticleItem/ArticleItem.styles';
+import { theme } from '@/styles/Theme';
 import { PopularArticleItemCardStyle } from '@/styles/cardStyle';
 import { CommonArticleType } from '@/types/articleResponse';
 import { convertGithubAvatarUrlForResize, dateTimeConverter } from '@/utils/converter';
+import { css } from '@emotion/react';
 
 const PopularArticleItem = ({
 	article,
 	isActive,
+	onClick,
 }: {
 	article: CommonArticleType;
 	isActive: boolean;
+	onClick: () => void;
 }) => {
-	const navigate = useNavigate();
-	const { id, title, author, commentCount, views, likeCount, category } = article;
-
-	const handleClickTitle = () => {
-		navigate(`/articles/${category}/${id}`);
-	};
+	const { title, author, commentCount, views, createdAt, tag } = article;
 	return (
 		<>
-			<Card {...PopularArticleItemCardStyle} isActive={isActive}>
-				<S.ArticleItemTitle>
-					<div>{article.title}</div>
-				</S.ArticleItemTitle>
-				<S.ArticleInfoBox>
-					<S.ArticleTimeStamp>{dateTimeConverter(article.createdAt)}</S.ArticleTimeStamp>
-					<S.ArticleInfoSubBox>
-						<S.CommentCount>댓글 수 {article.commentCount}</S.CommentCount>
-						<S.Views>조회 수 {article.views}</S.Views>
-					</S.ArticleInfoSubBox>
-				</S.ArticleInfoBox>
-				<S.HashTagListBox>
-					{article.tag &&
-						article.tag.length >= 1 &&
-						article.tag.map((item) => <S.HashTagItem key={item}>#{item}</S.HashTagItem>)}
-				</S.HashTagListBox>
-				<S.FooterBox>
-					<S.ProfileBox>
-						<S.UserProfile src={convertGithubAvatarUrlForResize(article.author.avatarUrl)} />
-						<div>{article.author.name}</div>
-					</S.ProfileBox>
-					<S.RightFooterBox></S.RightFooterBox>
-				</S.FooterBox>
+			<Card {...PopularArticleItemCardStyle} isActive={isActive} onClick={onClick}>
+				<S.ProfileBox
+					css={css`
+						background: linear-gradient(to bottom, #5e0080 7%, #3399ff 96%);
+						opacity: 0.8;
+						box-shadow: 0, 0, 0, inset 0 0 4px #5e0080;
+						padding: ${theme.size.SIZE_012};
+						border-top-left-radius: ${theme.size.SIZE_010};
+						border-top-right-radius: ${theme.size.SIZE_010};
+						margin-bottom: 1rem;
+					`}
+				>
+					<S.UserProfile
+						src={convertGithubAvatarUrlForResize(author.avatarUrl)}
+						css={css`
+							border: 2px solid transparent;
+							background-image: linear-gradient(to bottom, #ffffcc 7%, #ff9900 96%),
+								linear-gradient(to bottom, #ff3300 7%, #66ffcc 96%);
+							background-origin: border-box;
+							background-clip: content-box, border-box;
+						`}
+					/>
+					<div>{author.name}</div>
+				</S.ProfileBox>
+				<div
+					css={css`
+						padding: ${theme.size.SIZE_014};
+					`}
+				>
+					<S.ArticleItemTitle
+						css={css`
+							height: inherit;
+						`}
+					>
+						<div>{title}</div>
+					</S.ArticleItemTitle>
+					<S.ArticleInfoBox>
+						<S.ArticleTimeStamp>{dateTimeConverter(createdAt)}</S.ArticleTimeStamp>
+						<S.ArticleInfoSubBox>
+							<S.CommentCount>댓글 수 {commentCount}</S.CommentCount>
+							<S.Views>조회 수 {views}</S.Views>
+						</S.ArticleInfoSubBox>
+					</S.ArticleInfoBox>
+					<S.HashTagListBox>
+						{tag &&
+							tag.length >= 1 &&
+							tag.map((item) => <S.HashTagItem key={item}>#{item}</S.HashTagItem>)}
+					</S.HashTagListBox>
+					<S.FooterBox>
+						<S.RightFooterBox></S.RightFooterBox>
+					</S.FooterBox>
+				</div>
 			</Card>
 		</>
 	);

--- a/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
+++ b/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
@@ -1,9 +1,9 @@
-import { CAROUSEL_AUTO_PLAY_TIME } from '../../../constants/index';
 import { useEffect, useRef } from 'react';
 
 import Card from '@/components/@common/Card/Card';
 import * as S from '@/components/article/ArticleItem/ArticleItem.styles';
 import * as PopularS from '@/components/article/PopularArticleItem/PopularArticleItem.styles';
+import { CAROUSEL_AUTO_PLAY_TIME } from '@/constants/index';
 import { theme } from '@/styles/Theme';
 import { PopularArticleItemCardStyle } from '@/styles/cardStyle';
 import { CommonArticleType } from '@/types/articleResponse';

--- a/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
+++ b/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
@@ -26,7 +26,7 @@ const PopularArticleItem = ({
 
 	useEffect(() => {
 		if (isActive && rightSlide) {
-			timerId.current = window.setTimeout(rightSlide, 5000);
+			timerId.current = window.setTimeout(rightSlide, 3000);
 		}
 
 		return () => {

--- a/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
+++ b/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
@@ -40,7 +40,7 @@ const PopularArticleItem = ({
 			<Card {...PopularArticleItemCardStyle} isActive={isActive} onClick={onClick} role="tab">
 				<div
 					css={css`
-						background: #ba55d3;
+						background: ${category === 'question' ? theme.colors.RED_500 : theme.colors.BLUE_500};
 						opacity: 0.8;
 						box-shadow: 0, 0, 0, inset 0 0 4px #5e0080;
 						padding: ${theme.size.SIZE_012};

--- a/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
+++ b/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
@@ -37,7 +37,7 @@ const PopularArticleItem = ({
 
 	return (
 		<>
-			<Card {...PopularArticleItemCardStyle} isActive={isActive} onClick={onClick} role="link">
+			<Card {...PopularArticleItemCardStyle} isActive={isActive} onClick={onClick} role="tab">
 				<div
 					css={css`
 						background: #ba55d3;

--- a/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
+++ b/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
@@ -4,11 +4,9 @@ import Card from '@/components/@common/Card/Card';
 import * as S from '@/components/article/ArticleItem/ArticleItem.styles';
 import * as PopularS from '@/components/article/PopularArticleItem/PopularArticleItem.styles';
 import { CAROUSEL_AUTO_PLAY_TIME } from '@/constants/index';
-import { theme } from '@/styles/Theme';
 import { PopularArticleItemCardStyle } from '@/styles/cardStyle';
 import { CommonArticleType } from '@/types/articleResponse';
 import { convertGithubAvatarUrlForResize, dateTimeConverter } from '@/utils/converter';
-import { css } from '@emotion/react';
 
 const PopularArticleItem = ({
 	article,
@@ -38,51 +36,20 @@ const PopularArticleItem = ({
 	return (
 		<>
 			<Card {...PopularArticleItemCardStyle} isActive={isActive} onClick={onClick} role="tab">
-				<div
-					css={css`
-						background: ${category === 'question' ? theme.colors.RED_500 : theme.colors.BLUE_500};
-						opacity: 0.8;
-						box-shadow: 0, 0, 0, inset 0 0 4px #5e0080;
-						padding: ${theme.size.SIZE_012};
-						border-top-left-radius: ${theme.size.SIZE_010};
-						border-top-right-radius: ${theme.size.SIZE_010};
-						margin-bottom: 1rem;
-					`}
-				>
+				<PopularS.PopularArticleHeader category={category}>
 					<S.ProfileBox>
-						<S.UserProfile
+						<PopularS.PopularArticleUserProfile
 							src={convertGithubAvatarUrlForResize(author.avatarUrl)}
 							alt="프로필 이미지"
-							css={css`
-								border: 2px solid transparent;
-								background-image: linear-gradient(to bottom, #ffffcc 7%, #ff9900 96%),
-									linear-gradient(to bottom, #ff3300 7%, #66ffcc 96%);
-								background-origin: border-box;
-								background-clip: content-box, border-box;
-							`}
 						/>
-						<div
-							css={css`
-								color: white;
-							`}
-						>
-							{author.name}
-						</div>
+						<PopularS.AuthorNameText>{author.name}</PopularS.AuthorNameText>
 						<PopularS.CategoryBox categoryType={category}>{한글_카테고리}</PopularS.CategoryBox>
 					</S.ProfileBox>
-				</div>
-				<div
-					css={css`
-						padding: ${theme.size.SIZE_014};
-					`}
-				>
-					<S.ArticleItemTitle
-						css={css`
-							height: inherit;
-						`}
-					>
+				</PopularS.PopularArticleHeader>
+				<PopularS.PopularArticleContent>
+					<PopularS.PopularArticleItemTitle>
 						<div>{title}</div>
-					</S.ArticleItemTitle>
+					</PopularS.PopularArticleItemTitle>
 					<S.ArticleInfoBox>
 						<S.ArticleTimeStamp>{dateTimeConverter(createdAt)}</S.ArticleTimeStamp>
 						<S.ArticleInfoSubBox>
@@ -101,12 +68,7 @@ const PopularArticleItem = ({
 						</S.ArticleInfoSubBox>
 					</S.ArticleInfoBox>
 
-					<S.HashTagListBox
-						css={css`
-							margin: 1rem 0;
-							height: inherit;
-						`}
-					>
+					<PopularS.PopularArticleHashTagListBox>
 						{tag &&
 							tag.length >= 1 &&
 							tag.map((item) => (
@@ -115,8 +77,8 @@ const PopularArticleItem = ({
 									{item}
 								</S.HashTagItem>
 							))}
-					</S.HashTagListBox>
-				</div>
+					</PopularS.PopularArticleHashTagListBox>
+				</PopularS.PopularArticleContent>
 			</Card>
 		</>
 	);

--- a/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
+++ b/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
@@ -1,5 +1,8 @@
+import { useEffect, useRef } from 'react';
+
 import Card from '@/components/@common/Card/Card';
 import * as S from '@/components/article/ArticleItem/ArticleItem.styles';
+import * as PopularS from '@/components/article/PopularArticle/PopularArticle.styles';
 import { theme } from '@/styles/Theme';
 import { PopularArticleItemCardStyle } from '@/styles/cardStyle';
 import { CommonArticleType } from '@/types/articleResponse';
@@ -10,18 +13,31 @@ const PopularArticleItem = ({
 	article,
 	isActive,
 	onClick,
+	rightSlide,
 }: {
 	article: CommonArticleType;
 	isActive: boolean;
-	onClick: () => void;
+	onClick?: () => void;
+	rightSlide?: () => void;
 }) => {
 	const { title, author, commentCount, views, createdAt, tag } = article;
+	const timerId = useRef<number | undefined>(undefined);
+	useEffect(() => {
+		if (isActive && rightSlide) {
+			timerId.current = window.setTimeout(rightSlide, 5000);
+		}
+
+		return () => {
+			window.clearTimeout(timerId.current);
+		};
+	}, [isActive, rightSlide]);
+
 	return (
 		<>
 			<Card {...PopularArticleItemCardStyle} isActive={isActive} onClick={onClick}>
-				<S.ProfileBox
+				<div
 					css={css`
-						background: linear-gradient(to bottom, #5e0080 7%, #3399ff 96%);
+						background: #ba55d3;
 						opacity: 0.8;
 						box-shadow: 0, 0, 0, inset 0 0 4px #5e0080;
 						padding: ${theme.size.SIZE_012};
@@ -30,18 +46,26 @@ const PopularArticleItem = ({
 						margin-bottom: 1rem;
 					`}
 				>
-					<S.UserProfile
-						src={convertGithubAvatarUrlForResize(author.avatarUrl)}
-						css={css`
-							border: 2px solid transparent;
-							background-image: linear-gradient(to bottom, #ffffcc 7%, #ff9900 96%),
-								linear-gradient(to bottom, #ff3300 7%, #66ffcc 96%);
-							background-origin: border-box;
-							background-clip: content-box, border-box;
-						`}
-					/>
-					<div>{author.name}</div>
-				</S.ProfileBox>
+					<S.ProfileBox>
+						<S.UserProfile
+							src={convertGithubAvatarUrlForResize(author.avatarUrl)}
+							css={css`
+								border: 2px solid transparent;
+								background-image: linear-gradient(to bottom, #ffffcc 7%, #ff9900 96%),
+									linear-gradient(to bottom, #ff3300 7%, #66ffcc 96%);
+								background-origin: border-box;
+								background-clip: content-box, border-box;
+							`}
+						/>
+						<div
+							css={css`
+								color: white;
+							`}
+						>
+							{author.name}
+						</div>
+					</S.ProfileBox>
+				</div>
 				<div
 					css={css`
 						padding: ${theme.size.SIZE_014};
@@ -57,18 +81,26 @@ const PopularArticleItem = ({
 					<S.ArticleInfoBox>
 						<S.ArticleTimeStamp>{dateTimeConverter(createdAt)}</S.ArticleTimeStamp>
 						<S.ArticleInfoSubBox>
-							<S.CommentCount>댓글 수 {commentCount}</S.CommentCount>
-							<S.Views>조회 수 {views}</S.Views>
+							<S.CommentCount>
+								<PopularS.CommentIcon />
+								{commentCount}
+							</S.CommentCount>
+							<S.Views>
+								<PopularS.ViewIcon /> {views}
+							</S.Views>
 						</S.ArticleInfoSubBox>
 					</S.ArticleInfoBox>
-					<S.HashTagListBox>
+
+					<S.HashTagListBox
+						css={css`
+							margin: 1rem 0;
+							height: inherit;
+						`}
+					>
 						{tag &&
 							tag.length >= 1 &&
 							tag.map((item) => <S.HashTagItem key={item}>#{item}</S.HashTagItem>)}
 					</S.HashTagListBox>
-					<S.FooterBox>
-						<S.RightFooterBox></S.RightFooterBox>
-					</S.FooterBox>
 				</div>
 			</Card>
 		</>

--- a/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
+++ b/frontend/src/components/article/PopularArticleItem/PopularArticleItem.tsx
@@ -70,12 +70,15 @@ const PopularArticleItem = ({
 
 					<PopularS.PopularArticleHashTagListBox>
 						{tag &&
-							tag.length >= 1 &&
-							tag.map((item) => (
-								<S.HashTagItem key={item}>
-									<span aria-label="해시태그">#</span>
-									{item}
-								</S.HashTagItem>
+							(tag.length >= 1 ? (
+								tag.map((item) => (
+									<S.HashTagItem key={item}>
+										<span aria-label="해시태그">#</span>
+										{item}
+									</S.HashTagItem>
+								))
+							) : (
+								<div>&nbsp;</div>
 							))}
 					</PopularS.PopularArticleHashTagListBox>
 				</PopularS.PopularArticleContent>

--- a/frontend/src/components/hashTag/HashTagSearchBox/HashTagSearchBox.styles.tsx
+++ b/frontend/src/components/hashTag/HashTagSearchBox/HashTagSearchBox.styles.tsx
@@ -55,4 +55,82 @@ export const HashTagListBox = styled.div`
 export const HashTagSearchResultDescription = styled.div`
 	width: 100%;
 	text-align: center;
+
+	gap: ${({ theme }) => theme.size.SIZE_004};
+`;
+
+export const HashTagItem = styled.button<{ isChecked: boolean }>`
+	width: fit-content;
+	height: fit-content;
+
+	background-color: transparent;
+
+	&:hover,
+	&:active {
+		cursor: pointer;
+	}
+
+	${({ theme, isChecked }) => css`
+		border: ${theme.size.SIZE_001} solid;
+		border-color: ${isChecked ? theme.colors.PURPLE_500 : theme.colors.BLACK_400};
+		border-radius: ${theme.size.SIZE_004};
+
+		padding: ${theme.size.SIZE_004};
+
+		background-color: ${isChecked ? theme.colors.PURPLE_500 : 'transparent'};
+
+		color: ${isChecked ? theme.colors.WHITE : theme.colors.BLACK_500};
+	`}
+`;
+
+export const HashTagButton = styled.button`
+	width: fit-content;
+	height: fit-content;
+
+	background-color: transparent;
+
+	&:hover,
+	&:active {
+		cursor: pointer;
+	}
+
+	${({ theme }) => css`
+		border: ${theme.size.SIZE_001} solid ${theme.colors.BLACK_400};
+		border-radius: ${theme.size.SIZE_004};
+		padding: ${theme.size.SIZE_004};
+	`}
+`;
+
+export const EmptyMsg = styled.div``;
+
+export const OpenButton = styled(AiOutlineDown)`
+	border: none;
+	background-color: transparent;
+
+	${({ theme }) => css`
+		font-size: ${theme.size.SIZE_024};
+		margin-left: ${theme.size.SIZE_010};
+
+		&:hover,
+		&:active {
+			color: ${theme.colors.PURPLE_500};
+			cursor: pointer;
+		}
+	`}
+`;
+
+export const CloseButton = styled(AiOutlineUp)`
+	border: none;
+	background-color: transparent;
+
+	${({ theme }) => css`
+		font-size: ${theme.size.SIZE_024};
+		margin-left: ${theme.size.SIZE_010};
+
+		&:hover,
+		&:active {
+			color: ${theme.colors.PURPLE_500};
+			cursor: pointer;
+		}
+	`}
 `;

--- a/frontend/src/components/search/SearchBar/SearchBar.styles.tsx
+++ b/frontend/src/components/search/SearchBar/SearchBar.styles.tsx
@@ -74,3 +74,12 @@ export const SearchButton = styled(AiOutlineSearch)`
 		}
 	`}
 `;
+
+export const SrOnlyLabel = styled.label`
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	clip-path: polygon(0 0, 0 0, 0 0);
+`;

--- a/frontend/src/components/search/SearchBar/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar/SearchBar.tsx
@@ -48,6 +48,7 @@ const SearchBar = ({ isValid }: { isValid: boolean }) => {
 				/>
 			)}
 			<S.SearchBarBox isSearchOpen={searchInputState.isSearchOpen}>
+				<S.SrOnlyLabel htmlFor="search-input">검색</S.SrOnlyLabel>
 				<S.SearchInput
 					type="text"
 					readOnly={isValid}
@@ -56,10 +57,15 @@ const SearchBar = ({ isValid }: { isValid: boolean }) => {
 					onChange={handleChangeSearchInput}
 					minLength={2}
 					maxLength={200}
-					aria-label="검색을 입력하는 창입니다"
+					id="search-input"
 				/>
-				<S.SearchButtonBox disabled={isValid} onClick={handleClickSearchButton}>
-					<S.SearchButton role="button" aria-label="검색하기 버튼" />
+				<S.SearchButtonBox
+					disabled={isValid}
+					onClick={handleClickSearchButton}
+					aria-label="검색하기"
+					type="button"
+				>
+					<S.SearchButton />
 				</S.SearchButtonBox>
 			</S.SearchBarBox>
 		</S.Container>

--- a/frontend/src/components/tempArticle/TemporaryArticleItem/TemporaryArticleItem.styles.tsx
+++ b/frontend/src/components/tempArticle/TemporaryArticleItem/TemporaryArticleItem.styles.tsx
@@ -1,3 +1,4 @@
+import { TextOverflow } from '@/styles/mixin';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -23,11 +24,7 @@ export const Container = styled.section`
 export const Title = styled.h2`
 	display: block;
 	width: 90%;
-
-	text-overflow: ellipsis;
-	overflow: hidden;
-	word-break: break-all;
-	white-space: nowrap;
+	${TextOverflow}
 
 	${({ theme }) => css`
 		font-size: ${theme.size.SIZE_016};

--- a/frontend/src/components/user/UserArticleItem/UserArticleItem.styles.tsx
+++ b/frontend/src/components/user/UserArticleItem/UserArticleItem.styles.tsx
@@ -1,5 +1,6 @@
 import { AiOutlineMessage } from 'react-icons/ai';
 
+import { TextOverflow } from '@/styles/mixin';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -52,10 +53,7 @@ export const ArticleTitleBox = styled.div`
 export const ArticleTitle = styled.div`
 	width: 80%;
 
-	overflow: hidden;
-	word-break: break-all;
-	white-space: nowrap;
-	text-overflow: ellipsis;
+	${TextOverflow}
 
 	${({ theme }) => css`
 		font-size: ${theme.size.SIZE_016};

--- a/frontend/src/components/user/UserCommentItem/UserCommentItem.styles.tsx
+++ b/frontend/src/components/user/UserCommentItem/UserCommentItem.styles.tsx
@@ -1,3 +1,4 @@
+import { TextOverflow } from '@/styles/mixin';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -35,10 +36,7 @@ export const ArticleBox = styled.div`
 export const ArticleTitle = styled.div`
 	width: 80%;
 	margin-left: ${({ theme }) => theme.size.SIZE_008};
-	overflow: hidden;
-	word-break: break-all;
-	white-space: nowrap;
-	text-overflow: ellipsis;
+	${TextOverflow}
 `;
 
 export const ArticleCategory = styled.div<{ isQuestion: boolean }>`

--- a/frontend/src/components/user/UserProfileIcon/UserProfileIcon.styles.tsx
+++ b/frontend/src/components/user/UserProfileIcon/UserProfileIcon.styles.tsx
@@ -15,3 +15,12 @@ export const UserProfile = styled.img`
 export const Container = styled.div`
 	position: relative;
 `;
+
+export const SrOnlyContainer = styled.div`
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	clip-path: polygon(0 0, 0 0, 0 0);
+`;

--- a/frontend/src/components/user/UserProfileIcon/UserProfileIcon.tsx
+++ b/frontend/src/components/user/UserProfileIcon/UserProfileIcon.tsx
@@ -45,10 +45,9 @@ const UserProfileIcon = () => {
 				}))
 			}
 			onKeyDown={handleUserProfileIconKeydown}
-			id="user-dropdown"
 		>
-			{isLoading && <S.UserProfile src={gongseek} alt="작성자 프로필" />}
-			{isSuccess && <S.UserProfile src={data?.avatarUrl} />}
+			{isLoading && <S.UserProfile src={gongseek} alt="임시 작성자 프로필" />}
+			{isSuccess && <S.UserProfile src={data?.avatarUrl} alt="작성자 프로필" />}
 			{dropdown.isOpen && <Dropdown onCloseDropdown={handleClickUserProfile} />}
 			{isLog && <S.SrOnlyContainer role="alert">닫힘</S.SrOnlyContainer>}
 		</S.Container>

--- a/frontend/src/components/user/UserProfileIcon/UserProfileIcon.tsx
+++ b/frontend/src/components/user/UserProfileIcon/UserProfileIcon.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 
 import gongseek from '@/assets/gongseek.png';
@@ -9,6 +10,23 @@ import { dropdownState } from '@/store/dropdownState';
 const UserProfileIcon = () => {
 	const { data, isLoading, isSuccess } = useGetUserInfo();
 	const [dropdown, setDropdown] = useRecoilState(dropdownState);
+	const [isLog, setIsLog] = useState(false);
+
+	useEffect(() => {
+		if (isLog) {
+			setIsLog(false);
+		}
+	}, [isLog]);
+
+	const handleUserProfileIconKeydown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+		if (e.key === 'Escape') {
+			setIsLog(true);
+
+			setDropdown({
+				isOpen: false,
+			});
+		}
+	};
 
 	const handleClickUserProfile = () => {
 		setDropdown((prev) => ({
@@ -17,20 +35,22 @@ const UserProfileIcon = () => {
 	};
 
 	return (
-		<S.Container>
-			{isLoading && <S.UserProfile src={gongseek} />}
-			{isSuccess && (
-				<S.UserProfile
-					src={data?.avatarUrl}
-					alt="유저의 프로필 이미지"
-					onClick={() =>
-						setDropdown((prev) => ({
-							isOpen: !prev.isOpen,
-						}))
-					}
-				/>
-			)}
+		<S.Container
+			role="button"
+			aria-label="드롭다운을 열려면 엔터를 누르세요"
+			tabIndex={0}
+			onClick={() =>
+				setDropdown((prev) => ({
+					isOpen: !prev.isOpen,
+				}))
+			}
+			onKeyDown={handleUserProfileIconKeydown}
+			id="user-dropdown"
+		>
+			{isLoading && <S.UserProfile src={gongseek} alt="작성자 프로필" />}
+			{isSuccess && <S.UserProfile src={data?.avatarUrl} />}
 			{dropdown.isOpen && <Dropdown onCloseDropdown={handleClickUserProfile} />}
+			{isLog && <S.SrOnlyContainer role="alert">닫힘</S.SrOnlyContainer>}
 		</S.Container>
 	);
 };

--- a/frontend/src/components/vote/VoteItem/VoteItem.tsx
+++ b/frontend/src/components/vote/VoteItem/VoteItem.tsx
@@ -1,5 +1,7 @@
+import ProgressiveBar from '@/components/@common/ProgressiveBar/ProgressiveBar';
 import * as S from '@/components/vote/VoteItem/VoteItem.styles';
 import usePostVoteItem from '@/hooks/vote/usePostVoteItem';
+import { theme } from '@/styles/Theme';
 import { convertIdxToVoteColorKey } from '@/utils/converter';
 
 export interface VoteItemProps {
@@ -25,6 +27,7 @@ const VoteItem = ({
 }: VoteItemProps) => {
 	const progressivePercent = Math.floor((itemVotes / totalVotes) * 100);
 	const { handleChangeVoteSelectButton } = usePostVoteItem(articleId);
+	const gradientColor = theme.voteGradientColors[convertIdxToVoteColorKey(colorIdx)];
 
 	return (
 		<S.Container>
@@ -44,12 +47,13 @@ const VoteItem = ({
 				</S.Title>
 			</S.TitleBox>
 
-			<S.ProgressiveBar>
-				<S.ProgressiveBarContent
-					percent={progressivePercent || 0}
-					colorKey={convertIdxToVoteColorKey(colorIdx)}
-				/>
-			</S.ProgressiveBar>
+			<ProgressiveBar
+				percent={progressivePercent}
+				gradientColor={gradientColor}
+				time={1}
+				width={theme.size.SIZE_170}
+				height={theme.size.SIZE_010}
+			/>
 		</S.Container>
 	);
 };

--- a/frontend/src/components/vote/VoteItem/VoteItem.tsx
+++ b/frontend/src/components/vote/VoteItem/VoteItem.tsx
@@ -4,6 +4,8 @@ import usePostVoteItem from '@/hooks/vote/usePostVoteItem';
 import { theme } from '@/styles/Theme';
 import { convertIdxToVoteColorKey } from '@/utils/converter';
 
+const VOTE_ITEM_PROGRESSIVE_TIEM = 1;
+
 export interface VoteItemProps {
 	voteItemId: number;
 	title: string;
@@ -50,7 +52,7 @@ const VoteItem = ({
 			<ProgressiveBar
 				percent={progressivePercent}
 				gradientColor={gradientColor}
-				time={1}
+				time={VOTE_ITEM_PROGRESSIVE_TIEM}
 				width={theme.size.SIZE_170}
 				height={theme.size.SIZE_010}
 			/>

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -7,3 +7,5 @@ export const CAROUSEL_ITEM_WIDTH = 335;
 export const DEBOUNCE_SCROLL_TIME = 100;
 
 export const CAROUSEL_AUTO_PLAY_TIME = 3000;
+
+export const DEBOUNCE_RESIZE_TIME = 300;

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -1,3 +1,9 @@
 export const ACCESSTOKEN_KEY = 'gongseekAccessToken';
 
 export const HASHTAG_COUNT = 5;
+
+export const CAROUSEL_ITEM_WIDTH = 335;
+
+export const DEBOUNCE_SCROLL_TIME = 100;
+
+export const CAROUSEL_AUTO_PLAY_TIME = 3000;

--- a/frontend/src/hooks/article/useGetPopularArticles.tsx
+++ b/frontend/src/hooks/article/useGetPopularArticles.tsx
@@ -1,25 +1,18 @@
 import { AxiosError } from 'axios';
-import { useEffect } from 'react';
 import { useQuery } from 'react-query';
 
 import { getPopularArticles, PopularArticles } from '@/api/article';
 import { ErrorMessage } from '@/constants/ErrorMessage';
 import useThrowCustomError from '@/hooks/common/useThrowCustomError';
 
-const useGetPopularArticles = (initCarousel: (maxArticleLength: number) => void) => {
-	const { data, error, isError, isSuccess, isLoading } = useQuery<
+const useGetPopularArticles = () => {
+	const { data, error, isError, isLoading } = useQuery<
 		PopularArticles,
 		AxiosError<{ errorCode: keyof typeof ErrorMessage; message: string }>
 	>('popular-articles', getPopularArticles, {
 		retry: 1,
 		refetchOnWindowFocus: false,
 	});
-
-	useEffect(() => {
-		if (isSuccess) {
-			initCarousel(data.articles.length);
-		}
-	}, [isSuccess]);
 
 	useThrowCustomError(isError, error);
 

--- a/frontend/src/hooks/article/useGetPopularArticles.tsx
+++ b/frontend/src/hooks/article/useGetPopularArticles.tsx
@@ -26,7 +26,6 @@ const useGetPopularArticles = (initCarousel: (maxArticleLength: number) => void)
 	return {
 		data,
 		isLoading,
-		isSuccess,
 	};
 };
 

--- a/frontend/src/hooks/article/useGetPopularArticles.tsx
+++ b/frontend/src/hooks/article/useGetPopularArticles.tsx
@@ -1,58 +1,32 @@
 import { AxiosError } from 'axios';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect } from 'react';
 import { useQuery } from 'react-query';
 
 import { getPopularArticles, PopularArticles } from '@/api/article';
-import * as S from '@/components/article/PopularArticle/PopularArticle.styles';
 import { ErrorMessage } from '@/constants/ErrorMessage';
 import useThrowCustomError from '@/hooks/common/useThrowCustomError';
 
-const useGetPopularArticles = () => {
-	const [currentIndex, setCurrentIndex] = useState(0);
-	const [indexLimit, setIndexLimit] = useState(0);
-	const mainArticleContent = useRef<HTMLDivElement>(null);
-
-	const { data, error, isError, isSuccess, isLoading, isIdle } = useQuery<
+const useGetPopularArticles = (initCarousel: (maxArticleLength: number) => void) => {
+	const { data, error, isError, isSuccess, isLoading } = useQuery<
 		PopularArticles,
 		AxiosError<{ errorCode: keyof typeof ErrorMessage; message: string }>
-	>('popular-articles', getPopularArticles, { retry: 1, refetchOnWindowFocus: false });
-
-	useThrowCustomError(isError, error);
+	>('popular-articles', getPopularArticles, {
+		retry: 1,
+		refetchOnWindowFocus: false,
+	});
 
 	useEffect(() => {
 		if (isSuccess) {
-			setIndexLimit(data.articles.length);
-			setCurrentIndex(0);
+			initCarousel(data.articles.length);
 		}
 	}, [isSuccess]);
 
-	const handleClickLeftArrowButton = () => {
-		if (currentIndex === 0) {
-			// 애니메이션
-			return;
-		}
-		setCurrentIndex(currentIndex - 1);
-		mainArticleContent.current?.animate(S.showPopularSlider, S.animationTiming);
-	};
-
-	const handleClickRightArrowButton = () => {
-		if (currentIndex === indexLimit - 1 || currentIndex === 9) {
-			// 애니메이션
-			return;
-		}
-		setCurrentIndex(currentIndex + 1);
-		mainArticleContent.current?.animate(S.showPopularSlider, S.animationTiming);
-	};
+	useThrowCustomError(isError, error);
 
 	return {
 		data,
 		isLoading,
-		isIdle,
 		isSuccess,
-		currentIndex,
-		handleClickLeftArrowButton,
-		handleClickRightArrowButton,
-		mainArticleContent,
 	};
 };
 

--- a/frontend/src/hooks/common/useCarousel.tsx
+++ b/frontend/src/hooks/common/useCarousel.tsx
@@ -23,7 +23,7 @@ const useCarousel = () => {
 			carouselElementRef.addEventListener('scroll', handleScrollEnd);
 
 			carouselElementRef.scrollTo({
-				left: 300,
+				left: 340,
 				behavior: 'auto',
 			});
 		}
@@ -39,7 +39,7 @@ const useCarousel = () => {
 		}
 
 		carouselElementRef?.scrollBy({
-			left: -300,
+			left: -340,
 			behavior: 'smooth',
 		});
 		setCurrentIndex((prev) => prev - 1);
@@ -51,7 +51,7 @@ const useCarousel = () => {
 		}
 
 		carouselElementRef?.scrollBy({
-			left: 300,
+			left: 340,
 			behavior: 'smooth',
 		});
 

--- a/frontend/src/hooks/common/useCarousel.tsx
+++ b/frontend/src/hooks/common/useCarousel.tsx
@@ -66,6 +66,7 @@ const useCarousel = () => {
 		handleLeftSlideEvent,
 		handleRightSlideEvent,
 		handleCarouselElementRef,
+		currentIndex,
 	};
 };
 

--- a/frontend/src/hooks/common/useCarousel.tsx
+++ b/frontend/src/hooks/common/useCarousel.tsx
@@ -43,6 +43,7 @@ const useCarousel = () => {
 
 	const handleScrollEnd = useCallback(() => {
 		setIsScroll(true);
+
 		if (timerId.current !== null) {
 			clearTimeout(timerId.current);
 		}
@@ -53,7 +54,7 @@ const useCarousel = () => {
 
 	useEffect(() => {
 		if (carouselElementRef) {
-			carouselItemWidth.current = carouselElementRef.scrollWidth / (CAROUSEL_ITEMS_LENGTH * 2);
+			carouselItemWidth.current = carouselElementRef.scrollWidth / (CAROUSEL_ITEMS_LENGTH * 1.5);
 			carouselElementRef.addEventListener('scroll', handleScrollEnd);
 			window.addEventListener('resize', setCarouselItemWidth);
 
@@ -90,7 +91,7 @@ const useCarousel = () => {
 	}, [currentIndex]);
 
 	const handleLeftSlideEvent = () => {
-		if (currentIndex === MIN_CAROUSEL_INDEX || isScroll) {
+		if (prevCurrentIndex === MIN_CAROUSEL_INDEX || isScroll) {
 			return;
 		}
 

--- a/frontend/src/hooks/common/useCarousel.tsx
+++ b/frontend/src/hooks/common/useCarousel.tsx
@@ -1,0 +1,46 @@
+import { useRef, useState } from 'react';
+
+const useCarousel = () => {
+	const [currentIndex, setCurrentIndex] = useState(0);
+	const [indexLimit, setIndexLimit] = useState(0);
+	const carouselElement = useRef<HTMLDivElement>(null);
+
+	const showPopularSlider = [{ transform: `translateX(calc((-270px) * ${currentIndex}))` }];
+
+	const animationTiming = {
+		duration: 300,
+		fill: 'forwards',
+	} as const;
+
+	const initCarousel = (maxArticleLength: number) => {
+		setCurrentIndex(0);
+		setIndexLimit(maxArticleLength);
+	};
+
+	const handleLeftSlideEvent = () => {
+		if (currentIndex === 0) {
+			// 애니메이션
+			return;
+		}
+		setCurrentIndex(currentIndex - 1);
+		carouselElement.current?.animate(showPopularSlider, animationTiming);
+	};
+
+	const handleRightSlideEvent = () => {
+		if (currentIndex === indexLimit - 1 || currentIndex === 9) {
+			// 애니메이션
+			return;
+		}
+		setCurrentIndex(currentIndex + 1);
+		carouselElement.current?.animate(showPopularSlider, animationTiming);
+	};
+
+	return {
+		handleLeftSlideEvent,
+		handleRightSlideEvent,
+		initCarousel,
+		carouselElement,
+	};
+};
+
+export default useCarousel;

--- a/frontend/src/hooks/common/useCarousel.tsx
+++ b/frontend/src/hooks/common/useCarousel.tsx
@@ -6,8 +6,6 @@ const useCarousel = () => {
 	const [isScroll, setIsScroll] = useState(false);
 	const timerId = useRef<number | null>();
 
-	console.log(currentIndex);
-
 	const handleScrollEnd = () => {
 		setIsScroll(true);
 		if (timerId.current !== null) {
@@ -23,7 +21,7 @@ const useCarousel = () => {
 			carouselElementRef.addEventListener('scroll', handleScrollEnd);
 
 			carouselElementRef.scrollTo({
-				left: 340,
+				left: 335,
 				behavior: 'auto',
 			});
 		}
@@ -39,19 +37,28 @@ const useCarousel = () => {
 		}
 
 		carouselElementRef?.scrollBy({
-			left: -340,
+			left: -335,
 			behavior: 'smooth',
 		});
 		setCurrentIndex((prev) => prev - 1);
 	};
 
 	const handleRightSlideEvent = () => {
-		if (currentIndex === 9 || isScroll) {
+		if (isScroll) {
+			return;
+		}
+
+		if (currentIndex === 9) {
+			setCurrentIndex(0);
+			carouselElementRef?.scrollTo({
+				left: 335,
+				behavior: 'smooth',
+			});
 			return;
 		}
 
 		carouselElementRef?.scrollBy({
-			left: 340,
+			left: 335,
 			behavior: 'smooth',
 		});
 

--- a/frontend/src/hooks/common/useCarousel.tsx
+++ b/frontend/src/hooks/common/useCarousel.tsx
@@ -1,14 +1,25 @@
+import useDebounce from './useDebounce';
 import { useState, useCallback, useEffect, useRef } from 'react';
 
-import { CAROUSEL_ITEM_WIDTH, DEBOUNCE_SCROLL_TIME } from '@/constants';
+import { DEBOUNCE_RESIZE_TIME, DEBOUNCE_SCROLL_TIME } from '@/constants';
+
+const MIN_CAROUSEL_INDEX = 0;
+const MAX_CAROUSEL_INDEX = 9;
 
 const useCarousel = () => {
 	const [carouselElementRef, setCarouselElementRef] = useState<null | HTMLDivElement>(null);
 	const [currentIndex, setCurrentIndex] = useState(0);
 	const [isScroll, setIsScroll] = useState(false);
 	const timerId = useRef<number | null>();
+	const carouselItemWidth = useRef<number>(0);
 
-	const handleScrollEnd = () => {
+	const setCarouselItemWidth = useDebounce(() => {
+		if (carouselElementRef) {
+			carouselItemWidth.current = carouselElementRef.scrollWidth / 15;
+		}
+	}, DEBOUNCE_RESIZE_TIME);
+
+	const handleScrollEnd = useCallback(() => {
 		setIsScroll(true);
 		if (timerId.current !== null) {
 			clearTimeout(timerId.current);
@@ -16,30 +27,33 @@ const useCarousel = () => {
 		timerId.current = window.setTimeout(function () {
 			setIsScroll(false);
 		}, DEBOUNCE_SCROLL_TIME);
-	};
+	}, [timerId.current]);
 
 	useEffect(() => {
 		if (carouselElementRef) {
+			carouselItemWidth.current = carouselElementRef.scrollWidth / 15;
 			carouselElementRef.addEventListener('scroll', handleScrollEnd);
+			window.addEventListener('resize', setCarouselItemWidth);
 
 			carouselElementRef.scrollTo({
-				left: CAROUSEL_ITEM_WIDTH,
+				left: carouselItemWidth.current,
 				behavior: 'auto',
 			});
 		}
 
 		return () => {
 			carouselElementRef?.removeEventListener('scroll', handleScrollEnd);
+			window.removeEventListener('resize', setCarouselItemWidth);
 		};
 	}, [carouselElementRef]);
 
 	const handleLeftSlideEvent = () => {
-		if (currentIndex === 0 || isScroll) {
+		if (currentIndex === MIN_CAROUSEL_INDEX || isScroll) {
 			return;
 		}
 
 		carouselElementRef?.scrollBy({
-			left: -CAROUSEL_ITEM_WIDTH,
+			left: -carouselItemWidth.current,
 			behavior: 'smooth',
 		});
 		setCurrentIndex((prev) => prev - 1);
@@ -50,17 +64,17 @@ const useCarousel = () => {
 			return;
 		}
 
-		if (currentIndex === 9) {
-			setCurrentIndex(0);
+		if (currentIndex === MAX_CAROUSEL_INDEX) {
+			setCurrentIndex(MIN_CAROUSEL_INDEX);
 			carouselElementRef?.scrollTo({
-				left: CAROUSEL_ITEM_WIDTH,
+				left: carouselItemWidth.current,
 				behavior: 'smooth',
 			});
 			return;
 		}
 
 		carouselElementRef?.scrollBy({
-			left: CAROUSEL_ITEM_WIDTH,
+			left: carouselItemWidth.current,
 			behavior: 'smooth',
 		});
 

--- a/frontend/src/hooks/common/useCarousel.tsx
+++ b/frontend/src/hooks/common/useCarousel.tsx
@@ -1,5 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 
+import { CAROUSEL_ITEM_WIDTH, DEBOUNCE_SCROLL_TIME } from '@/constants';
+
 const useCarousel = () => {
 	const [carouselElementRef, setCarouselElementRef] = useState<null | HTMLDivElement>(null);
 	const [currentIndex, setCurrentIndex] = useState(0);
@@ -13,7 +15,7 @@ const useCarousel = () => {
 		}
 		timerId.current = window.setTimeout(function () {
 			setIsScroll(false);
-		}, 100);
+		}, DEBOUNCE_SCROLL_TIME);
 	};
 
 	useEffect(() => {
@@ -21,7 +23,7 @@ const useCarousel = () => {
 			carouselElementRef.addEventListener('scroll', handleScrollEnd);
 
 			carouselElementRef.scrollTo({
-				left: 335,
+				left: CAROUSEL_ITEM_WIDTH,
 				behavior: 'auto',
 			});
 		}
@@ -37,7 +39,7 @@ const useCarousel = () => {
 		}
 
 		carouselElementRef?.scrollBy({
-			left: -335,
+			left: -CAROUSEL_ITEM_WIDTH,
 			behavior: 'smooth',
 		});
 		setCurrentIndex((prev) => prev - 1);
@@ -51,14 +53,14 @@ const useCarousel = () => {
 		if (currentIndex === 9) {
 			setCurrentIndex(0);
 			carouselElementRef?.scrollTo({
-				left: 335,
+				left: CAROUSEL_ITEM_WIDTH,
 				behavior: 'smooth',
 			});
 			return;
 		}
 
 		carouselElementRef?.scrollBy({
-			left: 335,
+			left: CAROUSEL_ITEM_WIDTH,
 			behavior: 'smooth',
 		});
 

--- a/frontend/src/hooks/common/useCarousel.tsx
+++ b/frontend/src/hooks/common/useCarousel.tsx
@@ -1,8 +1,8 @@
-import useDebounce from './useDebounce';
-import usePrevState from './usePrevState';
 import { useState, useCallback, useEffect, useRef } from 'react';
 
 import { DEBOUNCE_RESIZE_TIME, DEBOUNCE_SCROLL_TIME } from '@/constants';
+import useDebounce from '@/hooks/common/useDebounce';
+import usePrevState from '@/hooks/common/usePrevState';
 
 const MIN_CAROUSEL_INDEX = 0;
 const MAX_CAROUSEL_INDEX = 9;

--- a/frontend/src/hooks/common/useCarousel.tsx
+++ b/frontend/src/hooks/common/useCarousel.tsx
@@ -1,4 +1,5 @@
 import useDebounce from './useDebounce';
+import usePrevState from './usePrevState';
 import { useState, useCallback, useEffect, useRef } from 'react';
 
 import { DEBOUNCE_RESIZE_TIME, DEBOUNCE_SCROLL_TIME } from '@/constants';
@@ -9,9 +10,29 @@ const MAX_CAROUSEL_INDEX = 9;
 const useCarousel = () => {
 	const [carouselElementRef, setCarouselElementRef] = useState<null | HTMLDivElement>(null);
 	const [currentIndex, setCurrentIndex] = useState(0);
+	const [scrollable, setScrollable] = useState(true);
 	const [isScroll, setIsScroll] = useState(false);
 	const timerId = useRef<number | null>();
 	const carouselItemWidth = useRef<number>(0);
+	const prevCurrentIndex = usePrevState(currentIndex);
+
+	useEffect(() => {
+		const handleBlurWindow = () => {
+			setScrollable(false);
+		};
+
+		const handleFocusWindow = () => {
+			setScrollable(true);
+		};
+
+		window.addEventListener('blur', handleBlurWindow);
+		window.addEventListener('focus', handleFocusWindow);
+
+		return () => {
+			window.removeEventListener('blur', handleBlurWindow);
+			window.removeEventListener('focus', handleFocusWindow);
+		};
+	}, []);
 
 	const setCarouselItemWidth = useDebounce(() => {
 		if (carouselElementRef) {
@@ -47,16 +68,27 @@ const useCarousel = () => {
 		};
 	}, [carouselElementRef]);
 
+	useEffect(() => {
+		if (prevCurrentIndex === MAX_CAROUSEL_INDEX) {
+			return;
+		}
+
+		const isRightSlide = prevCurrentIndex < currentIndex;
+
+		carouselElementRef?.scrollBy({
+			left: carouselItemWidth.current * (isRightSlide ? 1 : -1),
+			behavior: 'smooth',
+		});
+	}, [currentIndex]);
+
 	const handleLeftSlideEvent = () => {
 		if (currentIndex === MIN_CAROUSEL_INDEX || isScroll) {
 			return;
 		}
 
-		carouselElementRef?.scrollBy({
-			left: -carouselItemWidth.current,
-			behavior: 'smooth',
-		});
-		setCurrentIndex((prev) => prev - 1);
+		if (scrollable) {
+			setCurrentIndex((prev) => prev - 1);
+		}
 	};
 
 	const handleRightSlideEvent = () => {
@@ -66,6 +98,7 @@ const useCarousel = () => {
 
 		if (currentIndex === MAX_CAROUSEL_INDEX) {
 			setCurrentIndex(MIN_CAROUSEL_INDEX);
+
 			carouselElementRef?.scrollTo({
 				left: carouselItemWidth.current,
 				behavior: 'smooth',
@@ -73,12 +106,9 @@ const useCarousel = () => {
 			return;
 		}
 
-		carouselElementRef?.scrollBy({
-			left: carouselItemWidth.current,
-			behavior: 'smooth',
-		});
-
-		setCurrentIndex((prev) => prev + 1);
+		if (scrollable) {
+			setCurrentIndex((prev) => prev + 1);
+		}
 	};
 
 	const handleCarouselElementRef = useCallback((node: HTMLDivElement) => {

--- a/frontend/src/hooks/common/useCarousel.tsx
+++ b/frontend/src/hooks/common/useCarousel.tsx
@@ -37,7 +37,7 @@ const useCarousel = () => {
 
 	const setCarouselItemWidth = useDebounce(() => {
 		if (carouselElementRef) {
-			carouselItemWidth.current = carouselElementRef.scrollWidth / CAROUSEL_ITEMS_LENGTH;
+			carouselItemWidth.current = carouselElementRef.scrollWidth / (CAROUSEL_ITEMS_LENGTH * 2);
 		}
 	}, DEBOUNCE_RESIZE_TIME);
 

--- a/frontend/src/hooks/common/useCarousel.tsx
+++ b/frontend/src/hooks/common/useCarousel.tsx
@@ -6,6 +6,7 @@ import usePrevState from '@/hooks/common/usePrevState';
 
 const MIN_CAROUSEL_INDEX = 0;
 const MAX_CAROUSEL_INDEX = 9;
+const CAROUSEL_ITEMS_LENGTH = 10;
 
 const useCarousel = () => {
 	const [carouselElementRef, setCarouselElementRef] = useState<null | HTMLDivElement>(null);
@@ -36,7 +37,7 @@ const useCarousel = () => {
 
 	const setCarouselItemWidth = useDebounce(() => {
 		if (carouselElementRef) {
-			carouselItemWidth.current = carouselElementRef.scrollWidth / 15;
+			carouselItemWidth.current = carouselElementRef.scrollWidth / CAROUSEL_ITEMS_LENGTH;
 		}
 	}, DEBOUNCE_RESIZE_TIME);
 
@@ -52,7 +53,7 @@ const useCarousel = () => {
 
 	useEffect(() => {
 		if (carouselElementRef) {
-			carouselItemWidth.current = carouselElementRef.scrollWidth / 15;
+			carouselItemWidth.current = carouselElementRef.scrollWidth / (CAROUSEL_ITEMS_LENGTH * 2);
 			carouselElementRef.addEventListener('scroll', handleScrollEnd);
 			window.addEventListener('resize', setCarouselItemWidth);
 
@@ -63,7 +64,10 @@ const useCarousel = () => {
 		}
 
 		return () => {
-			carouselElementRef?.removeEventListener('scroll', handleScrollEnd);
+			if (carouselElementRef === null) {
+				return;
+			}
+			carouselElementRef.removeEventListener('scroll', handleScrollEnd);
 			window.removeEventListener('resize', setCarouselItemWidth);
 		};
 	}, [carouselElementRef]);
@@ -73,9 +77,13 @@ const useCarousel = () => {
 			return;
 		}
 
+		if (carouselElementRef === null) {
+			return;
+		}
+
 		const isRightSlide = prevCurrentIndex < currentIndex;
 
-		carouselElementRef?.scrollBy({
+		carouselElementRef.scrollBy({
 			left: carouselItemWidth.current * (isRightSlide ? 1 : -1),
 			behavior: 'smooth',
 		});
@@ -96,10 +104,14 @@ const useCarousel = () => {
 			return;
 		}
 
+		if (carouselElementRef === null) {
+			return;
+		}
+
 		if (currentIndex === MAX_CAROUSEL_INDEX) {
 			setCurrentIndex(MIN_CAROUSEL_INDEX);
 
-			carouselElementRef?.scrollTo({
+			carouselElementRef.scrollTo({
 				left: carouselItemWidth.current,
 				behavior: 'smooth',
 			});

--- a/frontend/src/hooks/common/useCarousel.tsx
+++ b/frontend/src/hooks/common/useCarousel.tsx
@@ -1,16 +1,23 @@
-import { useRef, useState } from 'react';
+import { useMemo, useRef, useState, useEffect } from 'react';
 
 const useCarousel = () => {
 	const [currentIndex, setCurrentIndex] = useState(0);
 	const [indexLimit, setIndexLimit] = useState(0);
 	const carouselElement = useRef<HTMLDivElement>(null);
 
-	const showPopularSlider = [{ transform: `translateX(calc((-270px) * ${currentIndex}))` }];
+	const showPopularSlider = useMemo(
+		() => [{ transform: `translateX(calc((-270px) * ${currentIndex}))` }],
+		[currentIndex],
+	);
 
 	const animationTiming = {
 		duration: 300,
 		fill: 'forwards',
 	} as const;
+
+	useEffect(() => {
+		carouselElement.current?.animate(showPopularSlider, animationTiming);
+	}, [currentIndex]);
 
 	const initCarousel = (maxArticleLength: number) => {
 		setCurrentIndex(0);
@@ -23,16 +30,14 @@ const useCarousel = () => {
 			return;
 		}
 		setCurrentIndex(currentIndex - 1);
-		carouselElement.current?.animate(showPopularSlider, animationTiming);
 	};
 
 	const handleRightSlideEvent = () => {
-		if (currentIndex === indexLimit - 1 || currentIndex === 9) {
+		if (currentIndex === indexLimit - 1) {
 			// 애니메이션
 			return;
 		}
 		setCurrentIndex(currentIndex + 1);
-		carouselElement.current?.animate(showPopularSlider, animationTiming);
 	};
 
 	return {

--- a/frontend/src/hooks/common/useDebounce.tsx
+++ b/frontend/src/hooks/common/useDebounce.tsx
@@ -1,0 +1,15 @@
+import { useRef } from 'react';
+
+const useDebounce = (func: (...args: unknown[]) => void, delay: number) => {
+	const timerId = useRef<number>();
+
+	return (...args: unknown[]) => {
+		if (timerId.current) {
+			window.clearTimeout(timerId.current);
+		}
+
+		timerId.current = window.setTimeout(func, delay, args);
+	};
+};
+
+export default useDebounce;

--- a/frontend/src/hooks/common/useEnterToClick.tsx
+++ b/frontend/src/hooks/common/useEnterToClick.tsx
@@ -19,7 +19,7 @@ const useEnterToClick = () => {
 		};
 	}, [ref.current]);
 
-	return { ref };
+	return [ref];
 };
 
 export default useEnterToClick;

--- a/frontend/src/hooks/common/useEnterToClick.tsx
+++ b/frontend/src/hooks/common/useEnterToClick.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from 'react';
+
+const useEnterToClick = () => {
+	const ref = useRef<HTMLDivElement | null>(null);
+
+	useEffect(() => {
+		const handleEnterKeydown = (e: KeyboardEvent) => {
+			if (e.key === 'Enter') {
+				(e.target as HTMLElement).click();
+			}
+		};
+
+		if (ref.current) {
+			ref.current.addEventListener('keyup', handleEnterKeydown);
+		}
+
+		return () => {
+			ref.current?.removeEventListener('keyup', handleEnterKeydown);
+		};
+	}, [ref.current]);
+
+	return { ref };
+};
+
+export default useEnterToClick;

--- a/frontend/src/hooks/common/usePageChange.tsx
+++ b/frontend/src/hooks/common/usePageChange.tsx
@@ -6,7 +6,7 @@ const usePageChange = (callback: (...args: unknown[]) => void) => {
 
 	useEffect(() => {
 		callback();
-	}, [location]);
+	}, [location.pathname]);
 };
 
 export default usePageChange;

--- a/frontend/src/hooks/common/usePrevState.tsx
+++ b/frontend/src/hooks/common/usePrevState.tsx
@@ -1,0 +1,13 @@
+import { useEffect, useRef } from 'react';
+
+const usePrevState = <T,>(state: T) => {
+	const ref = useRef<T>(state);
+
+	useEffect(() => {
+		ref.current = state;
+	}, [state]);
+
+	return ref.current;
+};
+
+export default usePrevState;

--- a/frontend/src/pages/Home/index.styles.tsx
+++ b/frontend/src/pages/Home/index.styles.tsx
@@ -40,6 +40,7 @@ export const CategoryTitle = styled.div<{ isActive: boolean }>`
 
 export const Container = styled.div`
 	display: flex;
+	position: relative;
 
 	flex-direction: column;
 	justify-content: center;

--- a/frontend/src/pages/Home/index.styles.tsx
+++ b/frontend/src/pages/Home/index.styles.tsx
@@ -8,7 +8,7 @@ export const CategoryTitleContainer = styled.div`
 	justify-content: space-between;
 	align-items: center;
 
-	margin-top: ${({ theme }) => theme.size.SIZE_050};
+	margin-top: ${({ theme }) => theme.size.SIZE_022};
 
 	z-index: ${({ theme }) => theme.zIndex.CATEGORY_TITLE_CONTAINER};
 `;

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -40,23 +40,23 @@ const Home = () => {
 				<PopularArticle />
 			</Suspense>
 			<S.CategoryTitleContainer>
-				<S.CategoryTitleBox role="tablist">
+				<S.CategoryTitleBox>
 					<S.CategoryTitle
 						isActive={currentCategory === 'question'}
 						onClick={() => handleClickCategoryTitle('question')}
-						role="tab"
 						tabIndex={0}
 						aria-pressed={currentCategory === 'question'}
+						role="button"
 						aria-live="polite"
 					>
 						질문
 					</S.CategoryTitle>
 					<S.CategoryTitle
 						isActive={currentCategory === 'discussion'}
-						onClick={() => handleClickCategoryTitle('discussion')}
-						role="tab"
+						onClick={() => setCurrentCategory('discussion')}
 						tabIndex={0}
 						aria-pressed={currentCategory === 'discussion'}
+						role="button"
 						aria-live="polite"
 					>
 						토론

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -18,7 +18,7 @@ const PopularArticle = React.lazy(
 );
 
 const Home = () => {
-	const { ref } = useEnterToClick();
+	const [enterRef] = useEnterToClick();
 
 	const navigate = useNavigate();
 
@@ -34,7 +34,7 @@ const Home = () => {
 	};
 
 	return (
-		<S.Container ref={ref}>
+		<S.Container ref={enterRef}>
 			<S.PopularArticleTitle id="popular-articles">오늘의 인기글</S.PopularArticleTitle>
 			<Suspense fallback={<Loading />}>
 				<PopularArticle />

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -35,7 +35,7 @@ const Home = () => {
 
 	return (
 		<S.Container ref={ref}>
-			<S.PopularArticleTitle>오늘의 인기글</S.PopularArticleTitle>
+			<S.PopularArticleTitle id="popular-articles">오늘의 인기글</S.PopularArticleTitle>
 			<Suspense fallback={<Loading />}>
 				<PopularArticle />
 			</Suspense>

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -1,10 +1,11 @@
-import React, { Suspense, useRef } from 'react';
+import React, { Suspense } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import EmptyMessage from '@/components/@common/EmptyMessage/EmptyMessage';
 import Loading from '@/components/@common/Loading/Loading';
 import SortDropdown from '@/components/@common/SortDropdown/SortDropDown';
 import useGetAllArticles from '@/hooks/article/useGetAllArticles';
+import useEnterToClick from '@/hooks/common/useEnterToClick';
 import * as S from '@/pages/Home/index.styles';
 import { CommonArticleType } from '@/types/articleResponse';
 
@@ -17,7 +18,8 @@ const PopularArticle = React.lazy(
 );
 
 const Home = () => {
-	const endFlag = useRef<HTMLDivElement>(null);
+	const { ref } = useEnterToClick();
+
 	const navigate = useNavigate();
 
 	const { data, currentCategory, setCurrentCategory, sortIndex, setSortIndex, fetchNextPage } =
@@ -32,7 +34,7 @@ const Home = () => {
 	};
 
 	return (
-		<S.Container ref={endFlag}>
+		<S.Container ref={ref}>
 			<S.PopularArticleTitle>오늘의 인기글</S.PopularArticleTitle>
 			<Suspense fallback={<Loading />}>
 				<PopularArticle />

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -40,16 +40,24 @@ const Home = () => {
 				<PopularArticle />
 			</Suspense>
 			<S.CategoryTitleContainer>
-				<S.CategoryTitleBox>
+				<S.CategoryTitleBox role="tablist">
 					<S.CategoryTitle
 						isActive={currentCategory === 'question'}
 						onClick={() => handleClickCategoryTitle('question')}
+						role="tab"
+						tabIndex={0}
+						aria-pressed={currentCategory === 'question'}
+						aria-live="polite"
 					>
 						질문
 					</S.CategoryTitle>
 					<S.CategoryTitle
 						isActive={currentCategory === 'discussion'}
 						onClick={() => handleClickCategoryTitle('discussion')}
+						role="tab"
+						tabIndex={0}
+						aria-pressed={currentCategory === 'discussion'}
+						aria-live="polite"
 					>
 						토론
 					</S.CategoryTitle>

--- a/frontend/src/styles/Theme.ts
+++ b/frontend/src/styles/Theme.ts
@@ -78,6 +78,7 @@ export const size = {
 	SIZE_030: '1.875rem',
 	SIZE_032: '2rem',
 	SIZE_035: '2.1875rem',
+	SIZE_038: '2.375rem',
 	SIZE_040: '2.5rem',
 	SIZE_050: '3.125rem',
 	SIZE_056: '3.5rem',

--- a/frontend/src/styles/Theme.ts
+++ b/frontend/src/styles/Theme.ts
@@ -27,6 +27,11 @@ export const voteGradientColors = {
 	VOTE_005: 'linear-gradient(-45deg, #F06966,#FAD6A6)',
 };
 
+export const GradientColors = {
+	POPULAR_PROFILE_BORDER:
+		'linear-gradient(to bottom, #ffffcc 7%, #ff9900 96%),linear-gradient(to bottom, #ff3300 7%, #66ffcc 96%)',
+};
+
 export const articleColors = {
 	ARTICLE_001: '#9055FF',
 	ARTICLE_002: '#13E2DA',
@@ -122,5 +127,6 @@ export const theme = {
 	size,
 	zIndex,
 	voteGradientColors,
+	GradientColors,
 	articleColors,
 } as const;

--- a/frontend/src/styles/cardStyle.ts
+++ b/frontend/src/styles/cardStyle.ts
@@ -12,7 +12,7 @@ export const PopularArticleItemCardStyle = {
 	media: {
 		minWidth: theme.breakpoints.DESKTOP_LARGE,
 		width: '50%',
-		height: theme.size.SIZE_220,
+		height: 'fit-content',
 	},
 
 	hasActiveAnimation: true,

--- a/frontend/src/styles/cardStyle.ts
+++ b/frontend/src/styles/cardStyle.ts
@@ -4,7 +4,6 @@ import { CardProps } from '@/types/card';
 export const PopularArticleItemCardStyle = {
 	cssObject: {
 		width: '85%',
-		padding: theme.size.SIZE_016,
 		height: 'fit-content',
 		flexShrink: '0',
 		scrollSnapAlign: 'center',

--- a/frontend/src/styles/cardStyle.ts
+++ b/frontend/src/styles/cardStyle.ts
@@ -1,6 +1,24 @@
 import { theme } from '@/styles/Theme';
 import { CardProps } from '@/types/card';
 
+export const PopularArticleItemCardStyle = {
+	cssObject: {
+		width: '85%',
+		padding: theme.size.SIZE_016,
+		height: 'fit-content',
+		flexShrink: '0',
+		scrollSnapAlign: 'center',
+		scrollSnapStop: 'always',
+	},
+	media: {
+		minWidth: theme.breakpoints.DESKTOP_LARGE,
+		width: '50%',
+		height: theme.size.SIZE_220,
+	},
+
+	hasActiveAnimation: true,
+};
+
 export const ArticleItemCardStyle: CardProps = {
 	cssObject: {
 		width: '80%',

--- a/frontend/src/styles/mixin.ts
+++ b/frontend/src/styles/mixin.ts
@@ -1,0 +1,11 @@
+import { css } from '@emotion/react';
+
+export const TextOverflow = css`
+	overflow: hidden;
+	text-overflow: ellipsis;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	word-wrap: break-word;
+	line-height: 1.2rem;
+`;

--- a/frontend/src/styles/reset.tsx
+++ b/frontend/src/styles/reset.tsx
@@ -114,11 +114,11 @@ export const reset = css`
 	:root {
 		font-size: 4vw;
 		@media (min-width: 420px) {
-			font-size: 3vw;
+			font-size: 2.5vw;
 		}
 
 		@media (min-width: 700px) {
-			font-size: 2vw;
+			font-size: 1.6vw;
 		}
 		@media (min-width: 1000px) {
 			font-size: 100%;

--- a/frontend/src/types/card.ts
+++ b/frontend/src/types/card.ts
@@ -1,3 +1,5 @@
+import { ElementType } from 'react';
+
 export interface CardProps {
 	cssObject: {
 		width: string;
@@ -23,4 +25,5 @@ export interface CardProps {
 	onClick?: () => void;
 	isActive?: boolean;
 	role?: string;
+	as?: ElementType;
 }

--- a/frontend/src/types/card.ts
+++ b/frontend/src/types/card.ts
@@ -22,4 +22,5 @@ export interface CardProps {
 	hasActiveAnimation: true | false;
 	onClick?: () => void;
 	isActive?: boolean;
+	role?: string;
 }

--- a/frontend/src/types/card.ts
+++ b/frontend/src/types/card.ts
@@ -21,4 +21,5 @@ export interface CardProps {
 	};
 	hasActiveAnimation: true | false;
 	onClick?: () => void;
+	isActive?: boolean;
 }

--- a/frontend/src/types/card.ts
+++ b/frontend/src/types/card.ts
@@ -10,6 +10,9 @@ export interface CardProps {
 		flexWrap?: string;
 		flexDirection?: string;
 		margin?: string;
+		flexShrink?: string;
+		scrollSnapAlign?: string;
+		scrollSnapStop?: string;
 	};
 	media?: {
 		minWidth: string;


### PR DESCRIPTION
close #657
close #785 

# 캐러셀 변경

## 데스크탑 ui
![데스크탑 캐러셀 - pr](https://user-images.githubusercontent.com/85891751/196333999-378f30de-8645-496e-af6f-38e6cc7dd382.gif)
## 모바일 ui
![모바일 캐러셀 - pr2](https://user-images.githubusercontent.com/85891751/196334176-06e0d8a2-1ff4-41ba-a1bd-a1b587d09927.gif)

## scroll기반 캐러셀

캐러셀을 구현하는것으로 `transform으로 이동하기`, `scroll로 이동하기` 크게 2개가 존재하는데 이번엔 scroll로 이동하기를 선택하였습니다.

`scroll-snap-type: x madatory`, `scroll-snap-align: center` 옵션을 동시에 설정하여 스크롤이 중간이상 넘어가게 된다면 모두 중앙으로 정렬되도록 하였습니다.

스크롤을 이동시킬때는 scrollTo, scrollBy를 이용하여 이동시켰습니다.

## useCarousel
useCarousel로 캐러셀을 움직이는 로직을 담았는데 처리해야되는 로직이 많아져서 밑에 추가 설명 작성하겠습니다!

### resize될때마다 변하는 크기 관리

현재 반응형 캐러셀을 이용하고 있기에 resize가 될때마다 다시 이동해야할 스크롤 너비를 계산하는 로직을 담았습니다. 

너무 빠르게 resize를 하게될시 현재 resize된 창의 너비가 아니라 지난 창의 너비가 반영되는 문제가 있어 debounce를 걸어서 마지막 resize후 일정시간동안 resize를 하지 않으면 그때 너비를 계산하는 로직을 작성하였습니다.

### 브라우저에서 blur될때 setState막기

브라우저에서 화면 포커싱을 다른곳으로 가져가면 scroll은 되지않지만 setState는 되는 문제가 있었습니다. 현재 3초에 한번 currentIndex를 setState한후 state가 변하면 그것에 따라 스크롤을 움직이는데 setState는 되지만 스크롤이 움직이지 않아 active가 이상하게 발생하는 문제가 있었습니다. 

window에 blue, focus 이벤트를 걸어 blur될시 setState를 막고, focus하면 다시 활성화하는 식으로 구현하였습니다.

### 스크롤 되는 도중에는 이동 못하도록 막기

현재 스크롤이 `smooth` 옵션으로 인해 부드럽게 넘어가게 되는데 스크롤이 이동하는 도중에 계속 다음버튼을 누를시 포커싱이 이상해지는 문제가 발생하였습니다. 

해결방법으로 isScroll라는 state로 스크롤이 진행중일때는 다음, 이전 버튼을 눌러도 반응하지 않도록 구현하였습니다.

# 홈페이지 웹접근성 향상

## 개선전
<img width="629" alt="스크린샷 2022-10-18 오후 1 32 56" src="https://user-images.githubusercontent.com/85891751/196336645-a5e2ec1f-9f1b-46b7-a5fd-1cf9a398e8bc.png">

## 개선후
<img width="687" alt="스크린샷 2022-10-18 오후 1 33 19" src="https://user-images.githubusercontent.com/85891751/196336658-bbb0cd88-02fd-43c3-8b57-8de726369eb4.png">

## 개선 방법

### 키보드로만 이용할 수 있게 하기

- tabIndex = 0을 이용하여 탭으로 컴포넌트들을 이동할 수 있도록 설정하였습니다.
- useEnterToClick을 이용하여 이용한 컴포넌트 내부는 모두 엔터를 하면 클릭처리가 되도록 설정하였습니다.
- keydown 이벤트를 이용하여 esc를 누를시 드롭다운을 닫을수 있도록 설정하였습니다.
- aria role의 tablist와 tab을 사용하였습니다.

### aria와 role이 맞도록 하기

- aria-pressed를 이용하는데 해당 요소가 button이 아니여서 `role = “button”`을 주어 해결하였습니다.

### img에 alt 넣기

- 프로필 이미지의 alt에 `프로필 이미지`를 넣었습니다.

### `#` 를 파운드 기호로 읽는다.

- `aria-label = “해시태그”` 를 이용하여 해결

### 링크 및 버튼에는 접근가능한 이름이 존재해야함.

현재 `검색 돋보기 버튼`, `이전 화살표 버튼`, `다음 화살표 버튼`등에 접근가능한 이름(텍스트)가 없어서 aria-label로 텍스트 부여

### input과 label을 연결

- 검색바의 input에 label  연결

### toLocalString으로 숫자를 붙혀서 읽을 수 있도록 설정

- `10011`의 숫자같은 경우 스크린리더기가 하나하나 끊어서 읽기 때문에 `10,111`로 만들어서 똑바로 만단위로 읽을수 있도록 `toLocaleString`을 설정해주었습니다.
