### PR TITLE
TabBar이 아이콘들을 정렬하고 댓글의 프로필 이미지 크기를 조정한다

### DIFF
--- a/frontend/src/components/@layout/TabBar/TabBar.styles.tsx
+++ b/frontend/src/components/@layout/TabBar/TabBar.styles.tsx
@@ -55,7 +55,7 @@ export const MenuLink = styled(AiOutlineMenu)`
 
 		color: ${theme.colors.BLACK_500};
 
-		margin: ${theme.size.SIZE_016} ${theme.size.SIZE_016} ${theme.size.SIZE_016}0;
+		margin: ${theme.size.SIZE_016} ${theme.size.SIZE_016} ${theme.size.SIZE_016} 0;
 
 		cursor: pointer;
 

--- a/frontend/src/components/comment/Comment/Comment.styles.tsx
+++ b/frontend/src/components/comment/Comment/Comment.styles.tsx
@@ -32,16 +32,20 @@ export const CommentInfo = styled.div`
 
 	justify-content: center;
 	gap: ${({ theme }) => theme.size.SIZE_004};
+	padding: ${({ theme }) => theme.size.SIZE_004};
 `;
 
 export const UserProfile = styled.img`
-	width: ${({ theme }) => theme.size.SIZE_050};
-	height: ${({ theme }) => theme.size.SIZE_050};
-
 	border-radius: 50%;
 
 	object-fit: cover;
 	object-position: center;
+
+	${({ theme }) => css`
+		width: ${theme.size.SIZE_035};
+		height: ${theme.size.SIZE_035};
+		padding: ${theme.size.SIZE_006};
+	`}
 `;
 
 export const CommentInfoSub = styled.div`

--- a/frontend/src/components/comment/CommentInputModal/CommentInputModal.styles.tsx
+++ b/frontend/src/components/comment/CommentInputModal/CommentInputModal.styles.tsx
@@ -56,6 +56,10 @@ export const CommentContainer = styled.div`
 			margin: 0 auto;
 			left: 0;
 			right: 0;
+
+			::-webkit-scrollbar {
+				display: none;
+			}
 		}
 	`}
 `;
@@ -134,6 +138,6 @@ export const SubmitBox = styled.div`
 			gap: ${theme.size.SIZE_016};
 
 			margin: ${theme.size.SIZE_040} ${theme.size.SIZE_026} ${theme.size.SIZE_020} 0;
-		}
+			
 	`}
 `;


### PR DESCRIPTION
close #784 
- tabBar 마지막 슬라이드로 이동하는 아이콘의 마진 값 조정 
- 댓글 입력창 DASKTOP_LARGE일 때에 스크롤 바 보이지 않도록 조정 
- 댓글에서의 유저 프로필 이미지 크기 줄이기 padding 값 부여 
<img width="935" alt="스크린샷 2022-10-18 오후 2 04 22" src="https://user-images.githubusercontent.com/60773373/196339902-8961f585-cddf-46ef-98ff-dcb37ae490dd.png">
