### PR TITLE
댓글의 임시저장 기능을 구현한다

### DIFF
--- a/frontend/src/components/comment/CommentContent/CommentContent.tsx
+++ b/frontend/src/components/comment/CommentContent/CommentContent.tsx
@@ -2,7 +2,7 @@ import EmptyMessage from '@/components/@common/EmptyMessage/EmptyMessage';
 import Comment from '@/components/comment/Comment/Comment';
 import * as S from '@/components/comment/CommentContent/CommentContent.styles';
 import CommentInputModal from '@/components/comment/CommentInputModal/CommentInputModal';
-import useDetailArticleState from '@/hooks/article/useDetailArticleState';
+import useDetailCommentState from '@/hooks/comment/useDetailCommentState';
 import { CommentType } from '@/types/commentResponse';
 
 export interface CommentContentProps {
@@ -12,7 +12,7 @@ export interface CommentContentProps {
 
 const CommentContent = ({ articleId, commentList }: CommentContentProps) => {
 	const { handleCommentPlusButton, isLogin, isCommentOpen, setIsCommentOpen } =
-		useDetailArticleState();
+		useDetailCommentState();
 	return (
 		<>
 			<S.CommentSection>

--- a/frontend/src/components/comment/CommentContent/CommentContent.tsx
+++ b/frontend/src/components/comment/CommentContent/CommentContent.tsx
@@ -1,10 +1,6 @@
-import { useNavigate } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
-
 import EmptyMessage from '@/components/@common/EmptyMessage/EmptyMessage';
 import Comment from '@/components/comment/Comment/Comment';
 import * as S from '@/components/comment/CommentContent/CommentContent.styles';
-import CommentInputModal from '@/components/comment/CommentInputModal/CommentInputModal';
 import useDetailCommentState from '@/hooks/comment/useDetailCommentState';
 import { CommentType } from '@/types/commentResponse';
 
@@ -14,26 +10,19 @@ export interface CommentContentProps {
 }
 
 const CommentContent = ({ articleId, commentList }: CommentContentProps) => {
-	const {
-		handleCommentPlusButton,
-		isLogin,
-		isCommentOpen,
-		setIsCommentOpen,
-		tempSavedComment,
-		setTempSavedComment,
-	} = useDetailCommentState();
+	const { handleClickCommentPlusButton, isLogin } = useDetailCommentState({ articleId });
 	return (
 		<>
 			<S.CommentSection>
 				<S.CommentInputBox>
 					<S.CommentInput
 						aria-label="댓글을 입력하는 창으로 이동하는 링크 입니다"
-						onClick={handleClickCommentButton}
+						onClick={handleClickCommentPlusButton}
 						disabled={!isLogin}
 					/>
 					<S.CreateCommentButton
 						aria-label="댓글을 입력하는 창으로 이동하는 링크입니다."
-						onClick={handleClickCommentButton}
+						onClick={handleClickCommentPlusButton}
 						disabled={!isLogin}
 					/>
 				</S.CommentInputBox>

--- a/frontend/src/components/comment/CommentContent/CommentContent.tsx
+++ b/frontend/src/components/comment/CommentContent/CommentContent.tsx
@@ -11,8 +11,14 @@ export interface CommentContentProps {
 }
 
 const CommentContent = ({ articleId, commentList }: CommentContentProps) => {
-	const { handleCommentPlusButton, isLogin, isCommentOpen, setIsCommentOpen } =
-		useDetailCommentState();
+	const {
+		handleCommentPlusButton,
+		isLogin,
+		isCommentOpen,
+		setIsCommentOpen,
+		tempSavedComment,
+		setTempSavedComment,
+	} = useDetailCommentState();
 	return (
 		<>
 			<S.CommentSection>
@@ -60,7 +66,8 @@ const CommentContent = ({ articleId, commentList }: CommentContentProps) => {
 						closeModal={() => setIsCommentOpen(false)}
 						articleId={articleId}
 						modalType="register"
-						placeholder=""
+						placeholder={tempSavedComment}
+						setTempSavedComment={setTempSavedComment}
 					/>
 				</>
 			)}

--- a/frontend/src/components/comment/CommentInputModal/CommentInputModal.tsx
+++ b/frontend/src/components/comment/CommentInputModal/CommentInputModal.tsx
@@ -1,5 +1,4 @@
 import { Dispatch, SetStateAction } from 'react';
-import reactDom from 'react-dom';
 
 import AnonymousCheckBox from '@/components/@common/AnonymousCheckBox/AnonymousCheckBox';
 import ToastUiEditor from '@/components/@common/ToastUiEditor/ToastUiEditor';
@@ -32,34 +31,14 @@ const CommentInputModal = ({
 	placeholder = '',
 	setTempSavedComment,
 }: CommentInputModalProps) => {
-	const commentModal = document.getElementById('comment-portal');
-
 	const { commentContent, setIsAnonymous, onClickCommentPostButton, putIsLoading, postIsLoading } =
 		useHandleCommentInputModalState({
-			closeModal,
 			articleId,
 			modalType,
 			commentId,
 			setTempSavedComment,
 		});
 
-	useEffect(() => {
-		if (commentContent.current) {
-			commentContent.current.getInstance().removeHook('addImageBlobHook');
-			commentContent.current.getInstance().addHook('addImageBlobHook', (blob, callback) => {
-				(async () => {
-					const formData = new FormData();
-					formData.append('imageFile', blob);
-					const url = await postImageUrlConverter(formData);
-					callback(url, 'alt-text');
-				})();
-			});
-		}
-	}, [commentContent]);
-
-	if (commentModal === null) {
-		throw new Error('모달을 찾지 못하였습니다.');
-	}
 	if (putIsLoading || postIsLoading) return <div>로딩중...</div>;
 
 	return (

--- a/frontend/src/components/comment/CommentInputModal/CommentInputModal.tsx
+++ b/frontend/src/components/comment/CommentInputModal/CommentInputModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
 import reactDom from 'react-dom';
 
 import AnonymousCheckBox from '@/components/@common/AnonymousCheckBox/AnonymousCheckBox';
@@ -18,6 +18,7 @@ export interface CommentInputModalProps {
 	modalType: 'edit' | 'register';
 	commentId?: string;
 	placeholder: string;
+	setTempSavedComment: Dispatch<SetStateAction<string>>;
 }
 
 const modalStatus = {
@@ -37,6 +38,7 @@ const CommentInputModal = ({
 	modalType,
 	commentId,
 	placeholder = '',
+	setTempSavedComment,
 }: CommentInputModalProps) => {
 	const commentModal = document.getElementById('comment-portal');
 	const [isAnonymous, setIsAnonymous] = useState(false);
@@ -62,6 +64,15 @@ const CommentInputModal = ({
 	useEffect(() => {
 		takeToastImgEditor(commentContent);
 	}, [commentContent]);
+
+	useEffect(() => {
+		const commentTempSavedInterval = setInterval(() => {
+			if (commentContent.current !== null) {
+				setTempSavedComment(commentContent.current.getInstance().getMarkdown());
+			}
+		}, 1000);
+		return () => clearInterval(commentTempSavedInterval);
+	}, []);
 
 	if (commentModal === null) {
 		throw new Error('모달을 찾지 못하였습니다.');

--- a/frontend/src/components/comment/CommentInputModal/CommentInputModal.tsx
+++ b/frontend/src/components/comment/CommentInputModal/CommentInputModal.tsx
@@ -1,16 +1,10 @@
-import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 import reactDom from 'react-dom';
 
 import AnonymousCheckBox from '@/components/@common/AnonymousCheckBox/AnonymousCheckBox';
 import ToastUiEditor from '@/components/@common/ToastUiEditor/ToastUiEditor';
 import * as S from '@/components/comment/CommentInputModal/CommentInputModal.styles';
-import usePostCommentInputModal from '@/hooks/comment/usePostCommentInputModal';
-import usePutCommentInputModal from '@/hooks/comment/usePutCommentInputModal';
-import useSnackBar from '@/hooks/common/useSnackBar';
-import { queryClient } from '@/index';
-import { takeToastImgEditor } from '@/utils/takeToastImgEditor';
-import { validatedCommentInput } from '@/utils/validateInput';
-import { Editor } from '@toast-ui/react-editor';
+import useHandleCommentInputModalState from '@/hooks/comment/useHandleCommentInputModalState';
 
 export interface CommentInputModalProps {
 	closeModal: () => void;
@@ -41,80 +35,19 @@ const CommentInputModal = ({
 	setTempSavedComment,
 }: CommentInputModalProps) => {
 	const commentModal = document.getElementById('comment-portal');
-	const [isAnonymous, setIsAnonymous] = useState(false);
-	const commentContent = useRef<Editor | null>(null);
-	const { showSnackBar } = useSnackBar();
-	const {
-		isLoading: postIsLoading,
-		mutate: postMutate,
-		isSuccess: postIsSuccess,
-	} = usePostCommentInputModal(closeModal);
-	const {
-		isLoading: putIsLoading,
-		mutate: putMutate,
-		isSuccess: putIsSuccess,
-	} = usePutCommentInputModal(closeModal);
 
-	useEffect(() => {
-		if (postIsSuccess || putIsSuccess) {
-			queryClient.refetchQueries('comments');
-		}
-	});
-
-	useEffect(() => {
-		takeToastImgEditor(commentContent);
-	}, [commentContent]);
-
-	useEffect(() => {
-		const commentTempSavedInterval = setInterval(() => {
-			if (commentContent.current !== null) {
-				setTempSavedComment(commentContent.current.getInstance().getMarkdown());
-			}
-		}, 1000);
-		return () => clearInterval(commentTempSavedInterval);
-	}, []);
+	const { commentContent, setIsAnonymous, onClickCommentPostButton, putIsLoading, postIsLoading } =
+		useHandleCommentInputModalState({
+			closeModal,
+			articleId,
+			modalType,
+			commentId,
+			setTempSavedComment,
+		});
 
 	if (commentModal === null) {
 		throw new Error('모달을 찾지 못하였습니다.');
 	}
-
-	const onClickCommentPostButton = () => {
-		if (modalType === 'register') {
-			handleCreateComment();
-			return;
-		}
-		handleEditComment();
-	};
-
-	const handleCreateComment = () => {
-		if (commentContent.current == null) {
-			return;
-		}
-		if (!validatedCommentInput(commentContent.current.getInstance().getMarkdown())) {
-			showSnackBar('댓글은 1자 이상, 10000자 이하로 작성해주세요');
-			return;
-		}
-		postMutate({
-			content: commentContent.current.getInstance().getMarkdown(),
-			id: articleId,
-			isAnonymous,
-		});
-	};
-
-	const handleEditComment = () => {
-		if (commentContent.current == null) {
-			return;
-		}
-		if (!validatedCommentInput(commentContent.current.getInstance().getMarkdown())) {
-			showSnackBar('댓글은 1자 이상, 10000자 이하로 작성해주세요');
-			return;
-		}
-		if (typeof commentId === 'undefined') {
-			throw new Error('댓글을 찾지 못하였습니다');
-		}
-		putMutate({ content: commentContent.current.getInstance().getMarkdown(), commentId });
-	};
-
 	if (putIsLoading || postIsLoading) return <div>로딩중...</div>;
 
 	return reactDom.createPortal(

--- a/frontend/src/hooks/comment/useDetailCommentState.tsx
+++ b/frontend/src/hooks/comment/useDetailCommentState.tsx
@@ -5,7 +5,7 @@ import { useRecoilValue } from 'recoil';
 import { URL } from '@/constants/url';
 import { getUserIsLogin } from '@/store/userState';
 
-const useDetailArticleState = () => {
+const useDetailCommentState = () => {
 	const [isCommentOpen, setIsCommentOpen] = useState(false);
 	const isLogin = useRecoilValue(getUserIsLogin);
 	const navigate = useNavigate();
@@ -28,4 +28,4 @@ const useDetailArticleState = () => {
 	};
 };
 
-export default useDetailArticleState;
+export default useDetailCommentState;

--- a/frontend/src/hooks/comment/useDetailCommentState.tsx
+++ b/frontend/src/hooks/comment/useDetailCommentState.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
@@ -7,6 +7,8 @@ import { getUserIsLogin } from '@/store/userState';
 
 const useDetailCommentState = () => {
 	const [isCommentOpen, setIsCommentOpen] = useState(false);
+	const [tempSavedComment, setTempSavedComment] = useState('');
+
 	const isLogin = useRecoilValue(getUserIsLogin);
 	const navigate = useNavigate();
 
@@ -25,6 +27,8 @@ const useDetailCommentState = () => {
 		isLogin,
 		isCommentOpen,
 		setIsCommentOpen,
+		tempSavedComment,
+		setTempSavedComment,
 	};
 };
 

--- a/frontend/src/hooks/comment/useDetailCommentState.tsx
+++ b/frontend/src/hooks/comment/useDetailCommentState.tsx
@@ -1,20 +1,34 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
 import { URL } from '@/constants/url';
+import useModal from '@/hooks/common/useModal';
 import { getUserIsLogin } from '@/store/userState';
 
-const useDetailCommentState = () => {
-	const [isCommentOpen, setIsCommentOpen] = useState(false);
+interface useDetailCommentStateProp {
+	articleId: string;
+}
+
+const useDetailCommentState = ({ articleId }: useDetailCommentStateProp) => {
 	const [tempSavedComment, setTempSavedComment] = useState('');
+	const { showModal } = useModal();
 
 	const isLogin = useRecoilValue(getUserIsLogin);
 	const navigate = useNavigate();
 
-	const handleCommentPlusButton = () => {
+	const handleClickCommentPlusButton = () => {
 		if (isLogin) {
-			setIsCommentOpen(true);
+			showModal({
+				modalType: 'comment-modal',
+				modalProps: {
+					articleId,
+					modalType: 'register',
+					placeholder: tempSavedComment,
+					setTempSavedComment,
+				},
+				isMobileOnly: false,
+			});
 			return;
 		}
 		if (window.confirm('로그인이 필요한 서비스입니다 로그인 창으로 이동하시겠습니까? ')) {
@@ -23,10 +37,8 @@ const useDetailCommentState = () => {
 	};
 
 	return {
-		handleCommentPlusButton,
+		handleClickCommentPlusButton,
 		isLogin,
-		isCommentOpen,
-		setIsCommentOpen,
 		tempSavedComment,
 		setTempSavedComment,
 	};

--- a/frontend/src/hooks/comment/useHandleCommentInputModalState.tsx
+++ b/frontend/src/hooks/comment/useHandleCommentInputModalState.tsx
@@ -52,9 +52,11 @@ const useHandleCommentInputModalState = ({
 	const onClickCommentPostButton = () => {
 		if (modalType === 'register') {
 			handleCreateComment();
+			setTempSavedComment('');
 			return;
 		}
 		handleEditComment();
+		setTempSavedComment('');
 	};
 
 	const handleCreateComment = () => {

--- a/frontend/src/hooks/comment/useHandleCommentInputModalState.tsx
+++ b/frontend/src/hooks/comment/useHandleCommentInputModalState.tsx
@@ -3,6 +3,7 @@ import { useRef, useState, useEffect } from 'react';
 import { CommentInputModalProps } from '@/components/comment/CommentInputModal/CommentInputModal';
 import usePostCommentInputModal from '@/hooks/comment/usePostCommentInputModal';
 import usePutCommentInputModal from '@/hooks/comment/usePutCommentInputModal';
+import useModal from '@/hooks/common/useModal';
 import useSnackBar from '@/hooks/common/useSnackBar';
 import { queryClient } from '@/index';
 import { takeToastImgEditor } from '@/utils/takeToastImgEditor';
@@ -10,7 +11,6 @@ import { validatedCommentInput } from '@/utils/validateInput';
 import { Editor } from '@toast-ui/react-editor';
 
 const useHandleCommentInputModalState = ({
-	closeModal,
 	articleId,
 	modalType,
 	commentId,
@@ -19,16 +19,17 @@ const useHandleCommentInputModalState = ({
 	const [isAnonymous, setIsAnonymous] = useState(false);
 	const commentContent = useRef<Editor | null>(null);
 	const { showSnackBar } = useSnackBar();
+	const { hideModal } = useModal();
 	const {
 		isLoading: postIsLoading,
 		mutate: postMutate,
 		isSuccess: postIsSuccess,
-	} = usePostCommentInputModal(closeModal);
+	} = usePostCommentInputModal(hideModal);
 	const {
 		isLoading: putIsLoading,
 		mutate: putMutate,
 		isSuccess: putIsSuccess,
-	} = usePutCommentInputModal(closeModal);
+	} = usePutCommentInputModal(hideModal);
 
 	useEffect(() => {
 		if (postIsSuccess || putIsSuccess) {

--- a/frontend/src/hooks/comment/useHandleCommentInputModalState.tsx
+++ b/frontend/src/hooks/comment/useHandleCommentInputModalState.tsx
@@ -1,0 +1,98 @@
+import { useRef, useState, useEffect } from 'react';
+
+import { CommentInputModalProps } from '@/components/comment/CommentInputModal/CommentInputModal';
+import usePostCommentInputModal from '@/hooks/comment/usePostCommentInputModal';
+import usePutCommentInputModal from '@/hooks/comment/usePutCommentInputModal';
+import useSnackBar from '@/hooks/common/useSnackBar';
+import { queryClient } from '@/index';
+import { takeToastImgEditor } from '@/utils/takeToastImgEditor';
+import { validatedCommentInput } from '@/utils/validateInput';
+import { Editor } from '@toast-ui/react-editor';
+
+const useHandleCommentInputModalState = ({
+	closeModal,
+	articleId,
+	modalType,
+	commentId,
+	setTempSavedComment,
+}: Omit<CommentInputModalProps, 'placeholder'>) => {
+	const [isAnonymous, setIsAnonymous] = useState(false);
+	const commentContent = useRef<Editor | null>(null);
+	const { showSnackBar } = useSnackBar();
+	const {
+		isLoading: postIsLoading,
+		mutate: postMutate,
+		isSuccess: postIsSuccess,
+	} = usePostCommentInputModal(closeModal);
+	const {
+		isLoading: putIsLoading,
+		mutate: putMutate,
+		isSuccess: putIsSuccess,
+	} = usePutCommentInputModal(closeModal);
+
+	useEffect(() => {
+		if (postIsSuccess || putIsSuccess) {
+			queryClient.refetchQueries('comments');
+		}
+	});
+
+	useEffect(() => {
+		takeToastImgEditor(commentContent);
+	}, [commentContent]);
+
+	useEffect(() => {
+		const commentTempSavedInterval = setInterval(() => {
+			if (commentContent.current !== null) {
+				setTempSavedComment(commentContent.current.getInstance().getMarkdown());
+			}
+		}, 1000);
+		return () => clearInterval(commentTempSavedInterval);
+	}, []);
+
+	const onClickCommentPostButton = () => {
+		if (modalType === 'register') {
+			handleCreateComment();
+			return;
+		}
+		handleEditComment();
+	};
+
+	const handleCreateComment = () => {
+		if (commentContent.current == null) {
+			return;
+		}
+		if (!validatedCommentInput(commentContent.current.getInstance().getMarkdown())) {
+			showSnackBar('댓글은 1자 이상, 10000자 이하로 작성해주세요');
+			return;
+		}
+		postMutate({
+			content: commentContent.current.getInstance().getMarkdown(),
+			id: articleId,
+			isAnonymous,
+		});
+	};
+
+	const handleEditComment = () => {
+		if (commentContent.current == null) {
+			return;
+		}
+		if (!validatedCommentInput(commentContent.current.getInstance().getMarkdown())) {
+			showSnackBar('댓글은 1자 이상, 10000자 이하로 작성해주세요');
+			return;
+		}
+		if (typeof commentId === 'undefined') {
+			throw new Error('댓글을 찾지 못하였습니다');
+		}
+		putMutate({ content: commentContent.current.getInstance().getMarkdown(), commentId });
+	};
+
+	return {
+		commentContent,
+		setIsAnonymous,
+		onClickCommentPostButton,
+		putIsLoading,
+		postIsLoading,
+	};
+};
+
+export default useHandleCommentInputModalState;

--- a/frontend/src/pages/UpdateWriting/index.tsx
+++ b/frontend/src/pages/UpdateWriting/index.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
-import { postImageUrlConverter } from '@/api/image';
 import Card from '@/components/@common/Card/Card';
 import Loading from '@/components/@common/Loading/Loading';
 import ToastUiEditor from '@/components/@common/ToastUiEditor/ToastUiEditor';

--- a/frontend/src/pages/UpdateWriting/index.tsx
+++ b/frontend/src/pages/UpdateWriting/index.tsx
@@ -9,6 +9,7 @@ import HashTag from '@/components/hashTag/HashTag/HashTag';
 import usePostWritingArticle from '@/hooks/article/usePostUpdateWritingArticle';
 import * as S from '@/pages/WritingArticles/index.styles';
 import { WritingCategoryCardStyle, WritingTitleCardStyle } from '@/styles/cardStyle';
+import { takeToastImgEditor } from '@/utils/takeToastImgEditor';
 
 const UpdateWriting = () => {
 	const { id } = useParams();
@@ -32,18 +33,7 @@ const UpdateWriting = () => {
 	} = usePostWritingArticle();
 
 	useEffect(() => {
-		if (content.current) {
-			content.current.getInstance().removeHook('addImageBlobHook');
-			content.current.getInstance().addHook('addImageBlobHook', (blob, callback) => {
-				(async () => {
-					const formData = new FormData();
-
-					formData.append('imageFile', blob);
-					const url = await postImageUrlConverter(formData);
-					callback(url, 'alt-text');
-				})();
-			});
-		}
+		takeToastImgEditor(content);
 	}, [content]);
 
 	if (isLoading) {

--- a/frontend/src/pages/WritingArticles/index.tsx
+++ b/frontend/src/pages/WritingArticles/index.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
-import { postImageUrlConverter } from '@/api/image';
 import AnonymousCheckBox from '@/components/@common/AnonymousCheckBox/AnonymousCheckBox';
 import Card from '@/components/@common/Card/Card';
 import Loading from '@/components/@common/Loading/Loading';
@@ -13,6 +12,7 @@ import useGetTempDetailArticles from '@/hooks/tempArticle/useGetTempDetailArticl
 import usePostTempArticle from '@/hooks/tempArticle/usePostTempArticle';
 import * as S from '@/pages/WritingArticles/index.styles';
 import { WritingCategoryCardStyle, WritingTitleCardStyle } from '@/styles/cardStyle';
+import { takeToastImgEditor } from '@/utils/takeToastImgEditor';
 
 const WritingArticles = ({ tempId = '' }: { tempId?: '' | number }) => {
 	const { category } = useParams();
@@ -85,18 +85,7 @@ const WritingArticles = ({ tempId = '' }: { tempId?: '' | number }) => {
 	}, [isTempDetailArticleSuccess]);
 
 	useEffect(() => {
-		if (content.current) {
-			content.current.getInstance().removeHook('addImageBlobHook');
-			content.current.getInstance().addHook('addImageBlobHook', (blob, callback) => {
-				(async () => {
-					const formData = new FormData();
-
-					formData.append('imageFile', blob);
-					const url = await postImageUrlConverter(formData);
-					callback(url, 'alt-text');
-				})();
-			});
-		}
+		takeToastImgEditor(content);
 	}, [content]);
 
 	if (isLoading) return <Loading />;

--- a/frontend/src/utils/takeToastImgEditor.ts
+++ b/frontend/src/utils/takeToastImgEditor.ts
@@ -1,0 +1,18 @@
+import { MutableRefObject } from 'react';
+
+import { postImageUrlConverter } from '@/api/image';
+import { Editor } from '@toast-ui/react-editor';
+
+export const takeToastImgEditor = (content: MutableRefObject<Editor | null>) => {
+	if (content.current) {
+		content.current.getInstance().removeHook('addImageBlobHook');
+		content.current.getInstance().addHook('addImageBlobHook', (blob, callback) => {
+			(async () => {
+				const formData = new FormData();
+				formData.append('imageFile', blob);
+				const url = await postImageUrlConverter(formData);
+				callback(url, 'alt-text');
+			})();
+		});
+	}
+};


### PR DESCRIPTION
close #772 

- 댓글의 입력값을 state로 관리하여 임시저장 
- inputModal을 ref로 관리하고 있어, 1초마다 임시저장 요청을 보내도록 수정 
- commentInputModal 컴포넌트 내에 너무 많은 로직이 존재하고 있어 훅으로 분리 
- commentPost관련 함수 분리 