### PR TITLE
투표 요청에는 voteItemId, 응답에는 votedItemId로 수정

### DIFF
--- a/frontend/src/api/vote.ts
+++ b/frontend/src/api/vote.ts
@@ -12,7 +12,7 @@ export interface VoteItems {
 export interface TVote {
 	articleId: string;
 	voteItems: VoteItems[];
-	voteItemId: number | null;
+	votedItemId: number | null;
 	isExpired: boolean;
 }
 

--- a/frontend/src/components/vote/Vote/Vote.tsx
+++ b/frontend/src/components/vote/Vote/Vote.tsx
@@ -24,7 +24,7 @@ const Vote = ({ articleId }: { articleId: string }) => {
 					data.voteItems.map((datum, idx) => (
 						<VoteItem
 							voteItemId={datum.id}
-							isVoted={data.voteItemId === datum.id}
+							isVoted={data.votedItemId === datum.id}
 							key={datum.id}
 							title={datum.content}
 							totalVotes={totalCount}

--- a/frontend/src/components/vote/VoteItem/VoteItem.tsx
+++ b/frontend/src/components/vote/VoteItem/VoteItem.tsx
@@ -4,7 +4,7 @@ import usePostVoteItem from '@/hooks/vote/usePostVoteItem';
 import { theme } from '@/styles/Theme';
 import { convertIdxToVoteColorKey } from '@/utils/converter';
 
-const VOTE_ITEM_PROGRESSIVE_TIEM = 1;
+const VOTE_ITEM_PROGRESSIVE_TIEM = 0.3;
 
 export interface VoteItemProps {
 	voteItemId: number;
@@ -27,7 +27,7 @@ const VoteItem = ({
 	isExpired,
 	isVoted,
 }: VoteItemProps) => {
-	const progressivePercent = Math.floor((itemVotes / totalVotes) * 100);
+	const progressivePercent = Math.floor((itemVotes / totalVotes) * 100) || 0;
 	const { handleChangeVoteSelectButton } = usePostVoteItem(articleId);
 	const gradientColor = theme.voteGradientColors[convertIdxToVoteColorKey(colorIdx)];
 

--- a/frontend/src/mock/vote.ts
+++ b/frontend/src/mock/vote.ts
@@ -25,7 +25,7 @@ export const VoteHandler = [
 						content: item,
 						amount: 0,
 					})),
-					voteItemId: null,
+					votedItemId: null,
 					isExpired: false,
 				}),
 			),


### PR DESCRIPTION
close #808 

## 버그상황

투표 요청에는 voteItemId, 응답에는 votedItemId로 수정
투표를 생성하고 바로 들어갈 시 itemVotes와 totalVotes가 모두 0이여서 나눌시 NaN이 나오게 되서 문제가 발생하였다.
Falsy한 값일 경우 0을 반환하는것으로 처리