### PR TITLE
refactor: 좋아요를 눌렀는지 확인하는 쿼리를 서브쿼리로 처리한다

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongseek/article/domain/repository/dto/ArticlePreviewDto.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/article/domain/repository/dto/ArticlePreviewDto.java
@@ -38,6 +38,7 @@ public class ArticlePreviewDto {
                              Long views,
                              Long commentCount,
                              Long likeCount,
+                             Boolean isLike,
                              LocalDateTime createdAt) {
         this(
                 id,
@@ -49,7 +50,7 @@ public class ArticlePreviewDto {
                 views,
                 commentCount,
                 likeCount,
-                null,
+                isLike,
                 createdAt
         );
     }

--- a/backend/src/main/java/com/woowacourse/gongseek/article/infra/repository/PagingArticleRepositoryImpl.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/article/infra/repository/PagingArticleRepositoryImpl.java
@@ -149,6 +149,7 @@ public class PagingArticleRepositoryImpl implements PagingArticleRepository {
                                 article.views.value,
                                 article.commentCount.value,
                                 article.likeCount.value,
+                                existsLike(memberId),
                                 article.createdAt
                         )
                 )
@@ -191,6 +192,7 @@ public class PagingArticleRepositoryImpl implements PagingArticleRepository {
                                 article.views.value,
                                 article.commentCount.value,
                                 article.likeCount.value,
+                                existsLike(memberId),
                                 article.createdAt
                         )
                 )
@@ -241,6 +243,7 @@ public class PagingArticleRepositoryImpl implements PagingArticleRepository {
                                 article.views.value,
                                 article.commentCount.value,
                                 article.likeCount.value,
+                                existsLike(memberId),
                                 article.createdAt
                         )
                 )
@@ -275,6 +278,7 @@ public class PagingArticleRepositoryImpl implements PagingArticleRepository {
                                 article.views.value,
                                 article.commentCount.value,
                                 article.likeCount.value,
+                                existsLike(memberId),
                                 article.createdAt
                         )
                 )

--- a/backend/src/test/java/com/woowacourse/gongseek/article/domain/repository/PagingArticleRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/article/domain/repository/PagingArticleRepositoryTest.java
@@ -71,9 +71,19 @@ public class PagingArticleRepositoryTest {
 
     @Test
     void 게시글을_5개씩_조회한다() {
-        for (int i = 0; i < 5; i++) {
-            articleRepository.save(new Article(TITLE, CONTENT, Category.QUESTION, member, true));
-        }
+        Article article1 = articleRepository.save(new Article(TITLE, CONTENT, Category.QUESTION, member, false));
+        Article article2 =articleRepository.save(new Article(TITLE, CONTENT, Category.QUESTION, member, true));
+        Article article3 = articleRepository.save(new Article(TITLE, CONTENT, Category.QUESTION, member, true));
+        Article article4 = articleRepository.save(new Article(TITLE, CONTENT, Category.QUESTION, member, true));
+        Article article5 = articleRepository.save(new Article(TITLE, CONTENT, Category.QUESTION, member, true));
+
+        System.out.println(article1.getMember().getName());
+        likeRepository.save(new Like(article1, member));
+        likeRepository.save(new Like(article2, member));
+        likeRepository.save(new Like(article3, member));
+        likeRepository.save(new Like(article4, member));
+        likeRepository.save(new Like(article5, member));
+
         Slice<ArticlePreviewDto> articles = pagingArticleRepository.findAllByPage(
                 null, 0L, Category.QUESTION.getValue(), "views", member.getId(), PageRequest.ofSize(5));
 
@@ -89,7 +99,7 @@ public class PagingArticleRepositoryTest {
                 () -> assertThat(articles.getContent().get(0).getViews()).isEqualTo(0L),
                 () -> assertThat(articles.getContent().get(0).getCommentCount()).isEqualTo(0L),
                 () -> assertThat(articles.getContent().get(0).getLikeCount()).isEqualTo(0L),
-                () -> assertThat(articles.getContent().get(0).getIsLike()).isFalse(),
+                () -> assertThat(articles.getContent().get(0).getIsLike()).isTrue(),
                 () -> assertThat(articles.hasNext()).isFalse()
         );
     }

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -25,6 +25,8 @@ spring:
         format_sql: true
         show_sql: true
     database-platform: org.hibernate.dialect.MySQL57Dialect
+  profiles:
+    active: test
 
 security:
   oauth2:


### PR DESCRIPTION
기존에 좋아요를 눌렀는 지 확인하는 쿼리는 따로 날리고 was내에서 for문으로 돌려서 dto에 넣어줬습니다.
서브쿼리를 적용해서 was에서 dto에 넣는 게 아닌 바로 디비에서 꺼내어 존재여부를 확인하고 처리슴다.

Close #873 