### PR TITLE
이미지 리사이징이 되지 않는 문제 해결

### DIFF
--- a/frontend/src/utils/converter.ts
+++ b/frontend/src/utils/converter.ts
@@ -77,7 +77,7 @@ export const convertGithubAvatarUrlForResize = (avatarUrl: string) => {
 		return avatarUrl;
 	}
 
-	if (typeof global.process === 'undefined') {
+	if (process.env.STORYBOOK) {
 		return avatarUrl;
 	}
 


### PR DESCRIPTION
close #877 

Storybook에서 이미지가 불러오지 않아서 처리한 분기가 실제 배포할때 리사이징 되지 않는 문제를 해결한다.