### PR TITLE
인터셉터에서 비회원 검증 로직 추가 및 리팩토링

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongseek/article/application/TempArticleService.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/article/application/TempArticleService.java
@@ -10,7 +10,6 @@ import com.woowacourse.gongseek.article.domain.repository.TempArticleRepository;
 import com.woowacourse.gongseek.article.exception.TempArticleNotFoundException;
 import com.woowacourse.gongseek.auth.application.dto.AppMember;
 import com.woowacourse.gongseek.auth.exception.NotAuthorException;
-import com.woowacourse.gongseek.auth.exception.NotMemberException;
 import com.woowacourse.gongseek.member.domain.Member;
 import com.woowacourse.gongseek.member.domain.repository.MemberRepository;
 import com.woowacourse.gongseek.member.exception.MemberNotFoundException;
@@ -30,19 +29,12 @@ public class TempArticleService {
 
     @Transactional
     public TempArticleIdResponse createOrUpdate(AppMember appMember, ArticleRequest tempArticleRequest) {
-        validateGuest(appMember);
         Member member = getMember(appMember.getPayload());
 
         if (isExistTempArticle(tempArticleRequest.getTempArticleId())) {
             return update(tempArticleRequest);
         }
         return create(tempArticleRequest, member);
-    }
-
-    private void validateGuest(AppMember appMember) {
-        if (appMember.isGuest()) {
-            throw new NotMemberException();
-        }
     }
 
     private Member getMember(Long memberId) {

--- a/backend/src/main/java/com/woowacourse/gongseek/article/infra/repository/PagingArticleRepositoryImpl.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/article/infra/repository/PagingArticleRepositoryImpl.java
@@ -30,6 +30,9 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 @Repository
 public class PagingArticleRepositoryImpl implements PagingArticleRepository {
+    private static final String VIEWS = "views";
+
+    private static final String ALL = "all";
 
     private final JPAQueryFactory queryFactory;
 
@@ -37,22 +40,7 @@ public class PagingArticleRepositoryImpl implements PagingArticleRepository {
     public Slice<ArticlePreviewDto> findAllByPage(Long cursorId, Long views, String category, String sortType,
                                                   Long memberId,
                                                   Pageable pageable) {
-        JPAQuery<ArticlePreviewDto> query = queryFactory
-                .select(
-                        Projections.constructor(
-                                ArticlePreviewDto.class,
-                                article.id,
-                                article.title.value,
-                                article.member,
-                                article.content.value,
-                                article.category,
-                                article.isAnonymous,
-                                article.views.value,
-                                count(comment),
-                                article.likeCount.value,
-                                article.createdAt
-                        )
-                )
+        JPAQuery<ArticlePreviewDto> query = selectArticlePreview()
                 .from(article)
                 .join(article.member, member)
                 .leftJoin(comment).on(article.id.eq(comment.article.id))
@@ -68,8 +56,27 @@ public class PagingArticleRepositoryImpl implements PagingArticleRepository {
         return convertToSliceFromArticle(fetch, pageable);
     }
 
+    private JPAQuery<ArticlePreviewDto> selectArticlePreview() {
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                ArticlePreviewDto.class,
+                                article.id,
+                                article.title.value,
+                                article.member,
+                                article.content.value,
+                                article.category,
+                                article.isAnonymous,
+                                article.views.value,
+                                count(comment),
+                                article.likeCount.value,
+                                article.createdAt
+                        )
+                );
+    }
+
     private BooleanExpression cursorIdAndCursorViews(Long cursorId, Long cursorViews, String sortType) {
-        if (sortType.equals("views")) {
+        if (sortType.equals(VIEWS)) {
             if (cursorId == null || cursorViews == null) {
                 return null;
             }
@@ -87,18 +94,18 @@ public class PagingArticleRepositoryImpl implements PagingArticleRepository {
     }
 
     private Expression[] articleId(String sortType) {
-        if (sortType.equals("views")) {
+        if (sortType.equals(VIEWS)) {
             return new Expression[]{article.views, article.id};
         }
         return new Expression[]{article.id};
     }
 
     private BooleanExpression categoryEquals(String category) {
-        return "all".equals(category) ? null : article.category.eq(Category.from(category));
+        return ALL.equals(category) ? null : article.category.eq(Category.from(category));
     }
 
     private List<ArticlePreviewDto> sort(String sortType, JPAQuery<ArticlePreviewDto> query) {
-        if (sortType.equals("views")) {
+        if (sortType.equals(VIEWS)) {
             return query.orderBy(article.views.value.desc(), article.id.desc()).fetch();
         }
         return query.orderBy(article.id.desc()).fetch();
@@ -153,22 +160,7 @@ public class PagingArticleRepositoryImpl implements PagingArticleRepository {
     @Override
     public Slice<ArticlePreviewDto> findAllByLikes(Long cursorId, Long cursorLike, String category, Long memberId,
                                                    Pageable pageable) {
-        List<ArticlePreviewDto> fetch = queryFactory
-                .select(
-                        Projections.constructor(
-                                ArticlePreviewDto.class,
-                                article.id,
-                                article.title.value,
-                                article.member,
-                                article.content.value,
-                                article.category,
-                                article.isAnonymous,
-                                article.views.value,
-                                count(comment),
-                                article.likeCount.value,
-                                article.createdAt
-                        )
-                )
+        List<ArticlePreviewDto> fetch = selectArticlePreview()
                 .from(article)
                 .join(article.member, member)
                 .leftJoin(comment).on(article.id.eq(comment.article.id))
@@ -197,22 +189,7 @@ public class PagingArticleRepositoryImpl implements PagingArticleRepository {
     @Override
     public Slice<ArticlePreviewDto> searchByContainingText(Long cursorId, String searchText, Long memberId,
                                                            Pageable pageable) {
-        List<ArticlePreviewDto> fetch = queryFactory
-                .select(
-                        Projections.constructor(
-                                ArticlePreviewDto.class,
-                                article.id,
-                                article.title.value,
-                                article.member,
-                                article.content.value,
-                                article.category,
-                                article.isAnonymous,
-                                article.views.value,
-                                count(comment),
-                                article.likeCount.value,
-                                article.createdAt
-                        )
-                )
+        List<ArticlePreviewDto> fetch = selectArticlePreview()
                 .from(article)
                 .join(article.member, member)
                 .leftJoin(comment).on(article.id.eq(comment.article.id))
@@ -236,22 +213,7 @@ public class PagingArticleRepositoryImpl implements PagingArticleRepository {
 
     @Override
     public Slice<ArticlePreviewDto> searchByAuthor(Long cursorId, String author, Long memberId, Pageable pageable) {
-        List<ArticlePreviewDto> fetch = queryFactory
-                .select(
-                        Projections.constructor(
-                                ArticlePreviewDto.class,
-                                article.id,
-                                article.title.value,
-                                article.member,
-                                article.content.value,
-                                article.category,
-                                article.isAnonymous,
-                                article.views.value,
-                                count(comment),
-                                article.likeCount.value,
-                                article.createdAt
-                        )
-                )
+        List<ArticlePreviewDto> fetch = selectArticlePreview()
                 .from(article)
                 .join(article.member, member)
                 .leftJoin(comment).on(article.id.eq(comment.article.id))
@@ -272,22 +234,7 @@ public class PagingArticleRepositoryImpl implements PagingArticleRepository {
     @Override
     public Slice<ArticlePreviewDto> searchByTag(Long cursorId, Long memberId, List<String> tagNames,
                                                 Pageable pageable) {
-        List<ArticlePreviewDto> fetch = queryFactory
-                .select(
-                        Projections.constructor(
-                                ArticlePreviewDto.class,
-                                article.id,
-                                article.title.value,
-                                article.member,
-                                article.content.value,
-                                article.category,
-                                article.isAnonymous,
-                                article.views.value,
-                                article.views.value,
-                                article.likeCount.value,
-                                article.createdAt
-                        )
-                )
+        List<ArticlePreviewDto> fetch = selectArticlePreview()
                 .distinct()
                 .from(articleTag)
                 .join(articleTag.article, article)

--- a/backend/src/main/java/com/woowacourse/gongseek/auth/application/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/auth/application/AuthService.java
@@ -47,13 +47,8 @@ public class AuthService {
     }
 
     public TokenResponse renewToken(UUID requestToken) {
-        RefreshToken refreshToken = refreshTokenRepository.findById(requestToken)
-                .orElseThrow(InvalidRefreshTokenException::new);
-        if (refreshToken.isIssue() || refreshToken.isExpired()) {
-            List<RefreshToken> refreshTokens = refreshTokenRepository.findAllByMemberId(refreshToken.getMemberId());
-            refreshTokenRepository.deleteAll(refreshTokens);
-            throw new InvalidRefreshTokenException();
-        }
+        RefreshToken refreshToken = getRefreshToken(requestToken);
+        ValidateRefreshToken(refreshToken);
         updateIssue(refreshToken);
 
         RefreshToken newRefreshToken = refreshTokenRepository.save(RefreshToken.create(refreshToken.getMemberId()));
@@ -64,9 +59,21 @@ public class AuthService {
                 .build();
     }
 
-    public void updateRefreshToken(UUID value) {
-        RefreshToken refreshToken = refreshTokenRepository.findById(value)
+    private RefreshToken getRefreshToken(UUID requestToken) {
+        return refreshTokenRepository.findById(requestToken)
                 .orElseThrow(InvalidRefreshTokenException::new);
+    }
+
+    private void ValidateRefreshToken(RefreshToken refreshToken) {
+        if (refreshToken.isIssue() || refreshToken.isExpired()) {
+            List<RefreshToken> refreshTokens = refreshTokenRepository.findAllByMemberId(refreshToken.getMemberId());
+            refreshTokenRepository.deleteAll(refreshTokens);
+            throw new InvalidRefreshTokenException();
+        }
+    }
+
+    public void updateRefreshToken(UUID value) {
+        RefreshToken refreshToken = getRefreshToken(value);
         updateIssue(refreshToken);
     }
 

--- a/backend/src/main/java/com/woowacourse/gongseek/auth/presentation/AuthenticationInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/auth/presentation/AuthenticationInterceptor.java
@@ -3,6 +3,7 @@ package com.woowacourse.gongseek.auth.presentation;
 import static org.hibernate.validator.internal.metadata.core.ConstraintHelper.PAYLOAD;
 
 import com.woowacourse.gongseek.auth.exception.InvalidAccessTokenException;
+import com.woowacourse.gongseek.auth.exception.NotMemberException;
 import com.woowacourse.gongseek.auth.infra.JwtTokenProvider;
 import com.woowacourse.gongseek.auth.utils.TokenExtractor;
 import javax.servlet.http.HttpServletRequest;
@@ -29,7 +30,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         }
 
         if (isGuest(request)) {
-            return true;
+            return checkHttpMethod(request);
         }
 
         String accessToken = TokenExtractor.extract(request.getHeader(HttpHeaders.AUTHORIZATION));
@@ -41,6 +42,13 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
     private boolean isGuest(HttpServletRequest request) {
         return request.getHeader(HttpHeaders.AUTHORIZATION).equals(GUEST_ACCESS_TOKEN);
+    }
+
+    private boolean checkHttpMethod(HttpServletRequest request) {
+        if (HttpMethod.GET.matches(request.getMethod())) {
+            return true;
+        }
+        throw new NotMemberException();
     }
 
     private void validateAccessToken(String accessToken) {

--- a/backend/src/main/java/com/woowacourse/gongseek/comment/application/CommentService.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/comment/application/CommentService.java
@@ -5,7 +5,6 @@ import com.woowacourse.gongseek.article.domain.repository.ArticleRepository;
 import com.woowacourse.gongseek.article.exception.ArticleNotFoundException;
 import com.woowacourse.gongseek.auth.application.dto.AppMember;
 import com.woowacourse.gongseek.auth.exception.NotAuthorException;
-import com.woowacourse.gongseek.auth.exception.NotMemberException;
 import com.woowacourse.gongseek.comment.application.dto.CommentRequest;
 import com.woowacourse.gongseek.comment.application.dto.CommentResponse;
 import com.woowacourse.gongseek.comment.application.dto.CommentUpdateRequest;
@@ -32,17 +31,10 @@ public class CommentService {
     private final CommentRepository commentRepository;
 
     public void create(AppMember appMember, Long articleId, CommentRequest commentRequest) {
-        validateGuest(appMember);
         Member member = getMember(appMember);
         Article article = getArticle(articleId);
 
         commentRepository.save(commentRequest.toComment(member, article));
-    }
-
-    private void validateGuest(AppMember appMember) {
-        if (appMember.isGuest()) {
-            throw new NotMemberException();
-        }
     }
 
     private Member getMember(AppMember appMember) {
@@ -59,16 +51,16 @@ public class CommentService {
     public CommentsResponse getAllByArticleId(AppMember appMember, Long articleId) {
         List<CommentResponse> responses = commentRepository.findAllByArticleIdWithMember(articleId)
                 .stream()
-                .map(comment -> checkGuest(comment, appMember))
+                .map(comment -> new CommentResponse(comment, checkGuest(comment, appMember)))
                 .collect(Collectors.toList());
         return new CommentsResponse(responses);
     }
 
-    private CommentResponse checkGuest(Comment comment, AppMember appMember) {
+    private boolean checkGuest(Comment comment, AppMember appMember) {
         if (appMember.isGuest()) {
-            return new CommentResponse(comment, false);
+            return false;
         }
-        return new CommentResponse(comment, comment.isAuthor(getMember(appMember)));
+        return comment.isAuthor(getMember(appMember));
     }
 
     public void update(AppMember appMember, Long commentId, CommentUpdateRequest updateRequest) {
@@ -77,7 +69,6 @@ public class CommentService {
     }
 
     private Comment checkAuthorization(AppMember appMember, Long commentId) {
-        validateGuest(appMember);
         Comment comment = getComment(commentId);
         Member member = getMember(appMember);
         validateAuthor(comment, member);

--- a/backend/src/main/java/com/woowacourse/gongseek/comment/application/CommentService.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/comment/application/CommentService.java
@@ -57,7 +57,8 @@ public class CommentService {
 
     @Transactional(readOnly = true)
     public CommentsResponse getAllByArticleId(AppMember appMember, Long articleId) {
-        List<CommentResponse> responses = commentRepository.findAllByArticleIdWithMember(articleId).stream()
+        List<CommentResponse> responses = commentRepository.findAllByArticleIdWithMember(articleId)
+                .stream()
                 .map(comment -> checkGuest(comment, appMember))
                 .collect(Collectors.toList());
         return new CommentsResponse(responses);
@@ -97,7 +98,6 @@ public class CommentService {
     public void delete(AppMember appMember, Long commentId) {
         Comment comment = checkAuthorization(appMember, commentId);
         commentRepository.delete(comment);
-        Article article = comment.getArticle();
     }
 }
 

--- a/backend/src/main/java/com/woowacourse/gongseek/comment/domain/repository/CommentRepository.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/comment/domain/repository/CommentRepository.java
@@ -13,6 +13,4 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query("select c from Comment c join fetch c.member where c.article.id = :articleId")
     List<Comment> findAllByArticleIdWithMember(@Param("articleId") Long articleId);
-
-    void deleteAllByArticleId(Long articleId);
 }

--- a/backend/src/main/java/com/woowacourse/gongseek/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/config/WebConfig.java
@@ -12,13 +12,13 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
+    private static final String ALLOWED_METHOD_NAMES = "GET,POST,PUT,DELETE,OPTIONS,PATCH";
+
     @Value("${cors.url.service}")
     private String serviceUrl;
 
     @Value("${cors.url.local}")
     private String localUrl;
-
-    public static final String ALLOWED_METHOD_NAMES = "GET,HEAD,POST,PUT,DELETE,TRACE,OPTIONS,PATCH";
 
     @Override
     public void addCorsMappings(final CorsRegistry registry) {

--- a/backend/src/main/java/com/woowacourse/gongseek/like/application/LikeService.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/like/application/LikeService.java
@@ -4,7 +4,6 @@ import com.woowacourse.gongseek.article.domain.Article;
 import com.woowacourse.gongseek.article.domain.repository.ArticleRepository;
 import com.woowacourse.gongseek.article.exception.ArticleNotFoundException;
 import com.woowacourse.gongseek.auth.application.dto.AppMember;
-import com.woowacourse.gongseek.auth.exception.NotMemberException;
 import com.woowacourse.gongseek.like.domain.Like;
 import com.woowacourse.gongseek.like.domain.repository.LikeRepository;
 import com.woowacourse.gongseek.member.domain.Member;
@@ -24,17 +23,10 @@ public class LikeService {
     private final ArticleRepository articleRepository;
 
     public void likeArticle(AppMember appMember, Long articleId) {
-        validateGuest(appMember);
         Member member = getMember(appMember);
         Article article = getArticle(articleId);
 
         saveByExistsLike(member, article);
-    }
-
-    private void validateGuest(AppMember appMember) {
-        if (appMember.isGuest()) {
-            throw new NotMemberException();
-        }
     }
 
     private Member getMember(AppMember appMember) {
@@ -55,17 +47,16 @@ public class LikeService {
     }
 
     public void unlikeArticle(AppMember appMember, Long articleId) {
-        validateGuest(appMember);
         Member member = getMember(appMember);
         Article article = getArticle(articleId);
 
-        deleteByExistsLike(member, article);
+        deleteByExistsLike(member.getId(), article.getId());
     }
 
-    private void deleteByExistsLike(Member member, Article article) {
-        if (likeRepository.existsByArticleIdAndMemberId(article.getId(), member.getId())) {
-            articleRepository.decreaseLikeCount(article.getId());
-            likeRepository.deleteByArticleIdAndMemberId(article.getId(), member.getId());
+    private void deleteByExistsLike(Long memberId, Long articleId) {
+        if (likeRepository.existsByArticleIdAndMemberId(articleId, memberId)) {
+            articleRepository.decreaseLikeCount(articleId);
+            likeRepository.deleteByArticleIdAndMemberId(articleId, memberId);
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongseek/like/domain/repository/LikeRepository.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/like/domain/repository/LikeRepository.java
@@ -1,11 +1,15 @@
 package com.woowacourse.gongseek.like.domain.repository;
 
+import com.woowacourse.gongseek.article.domain.Article;
 import com.woowacourse.gongseek.like.domain.Like;
+import com.woowacourse.gongseek.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
     void deleteByArticleIdAndMemberId(Long articleId, Long memberId);
+
+    void deleteByArticleAndMember(Article article, Member member);
 
     boolean existsByArticleIdAndMemberId(Long articleId, Long memberId);
 

--- a/backend/src/main/java/com/woowacourse/gongseek/like/domain/repository/LikeRepository.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/like/domain/repository/LikeRepository.java
@@ -1,15 +1,11 @@
 package com.woowacourse.gongseek.like.domain.repository;
 
-import com.woowacourse.gongseek.article.domain.Article;
 import com.woowacourse.gongseek.like.domain.Like;
-import com.woowacourse.gongseek.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
     void deleteByArticleIdAndMemberId(Long articleId, Long memberId);
-
-    void deleteByArticleAndMember(Article article, Member member);
 
     boolean existsByArticleIdAndMemberId(Long articleId, Long memberId);
 

--- a/backend/src/main/java/com/woowacourse/gongseek/vote/domain/VoteItems.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/vote/domain/VoteItems.java
@@ -11,11 +11,11 @@ public class VoteItems {
     private static final int MIN_VOTE_ITEM_COUNT = 2;
     private static final int MAX_VOTE_ITEM_COUNT = 5;
 
-    private final Set<VoteItem> voteItems;
+    private final Set<VoteItem> values;
 
     public VoteItems(Set<VoteItem> voteItems) {
         validateCount(voteItems);
-        this.voteItems = new LinkedHashSet<>(voteItems);
+        this.values = new LinkedHashSet<>(voteItems);
     }
 
     public static VoteItems of(List<String> voteItems, Vote vote) {
@@ -31,7 +31,7 @@ public class VoteItems {
         }
     }
 
-    public Set<VoteItem> getVoteItems() {
-        return new LinkedHashSet<>(voteItems);
+    public Set<VoteItem> getValues() {
+        return new LinkedHashSet<>(values);
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongseek/vote/domain/repository/VoteHistoryRepository.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/vote/domain/repository/VoteHistoryRepository.java
@@ -1,11 +1,8 @@
 package com.woowacourse.gongseek.vote.domain.repository;
 
 import com.woowacourse.gongseek.vote.domain.VoteHistory;
-import com.woowacourse.gongseek.vote.domain.VoteItem;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface VoteHistoryRepository extends JpaRepository<VoteHistory, Long>, VoteHistoryRepositoryCustom {
 
-    void deleteAllByVoteItemIn(List<VoteItem> voteItems);
 }

--- a/backend/src/main/java/com/woowacourse/gongseek/vote/domain/repository/VoteItemRepository.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/vote/domain/repository/VoteItemRepository.java
@@ -1,12 +1,8 @@
 package com.woowacourse.gongseek.vote.domain.repository;
 
 import com.woowacourse.gongseek.vote.domain.VoteItem;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface VoteItemRepository extends JpaRepository<VoteItem, Long>, VoteItemRepositoryCustom {
 
-    List<VoteItem> findAllByVoteArticleId(Long articleId);
-
-    List<VoteItem> findAllByVoteId(Long voteId);
 }

--- a/backend/src/test/java/com/woowacourse/gongseek/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/acceptance/MemberAcceptanceTest.java
@@ -128,8 +128,8 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
         //then
         assertAll(
-                () -> assertThat(updateResponse.getErrorCode()).isEqualTo("2001"),
-                () -> assertThat(updateResponse.getMessage()).contains("회원이 존재하지 않습니다.")
+                () -> assertThat(updateResponse.getErrorCode()).isEqualTo("1008"),
+                () -> assertThat(updateResponse.getMessage()).contains("회원이 아니므로 권한이 없습니다.")
         );
     }
 

--- a/backend/src/test/java/com/woowacourse/gongseek/acceptance/VoteAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/acceptance/VoteAcceptanceTest.java
@@ -189,7 +189,7 @@ public class VoteAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 비회원이_투표를_하면_투표수가_안_오른다() {
+    void 비회원이_투표를_하면_예외가_발생한다() {
         //given
         AccessTokenResponse tokenResponse = 로그인을_한다(슬로);
         Long articleId = 토론_게시글을_기명으로_등록한다(tokenResponse).getId();
@@ -210,8 +210,8 @@ public class VoteAcceptanceTest extends AcceptanceTest {
         ErrorResponse response = 투표를_한다(new AccessTokenResponse(null), articleId,
                 new SelectVoteItemIdRequest(votedItemId)).as(ErrorResponse.class);
         assertAll(
-                () -> assertThat(response.getErrorCode()).isEqualTo("2001"),
-                () -> assertThat(response.getMessage()).contains("회원이 존재하지 않습니다.")
+                () -> assertThat(response.getErrorCode()).isEqualTo("1008"),
+                () -> assertThat(response.getMessage()).contains("회원이 아니므로 권한이 없습니다.")
         );
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongseek/article/application/ArticleServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/article/application/ArticleServiceTest.java
@@ -20,7 +20,6 @@ import com.woowacourse.gongseek.auth.application.dto.AppMember;
 import com.woowacourse.gongseek.auth.application.dto.GuestMember;
 import com.woowacourse.gongseek.auth.application.dto.LoginMember;
 import com.woowacourse.gongseek.auth.exception.NotAuthorException;
-import com.woowacourse.gongseek.auth.exception.NotMemberException;
 import com.woowacourse.gongseek.like.application.LikeService;
 import com.woowacourse.gongseek.member.domain.Member;
 import com.woowacourse.gongseek.member.domain.repository.MemberRepository;
@@ -135,7 +134,7 @@ public class ArticleServiceTest extends IntegrationTest {
 
         assertAll(
                 () -> assertThat(articleIdResponse.getId()).isNotNull(),
-                () -> assertThat(foundArticle.getArticleTags().getValue()).hasSize(0)
+                () -> assertThat(foundArticle.getArticleTags().getValue()).isEmpty()
         );
     }
 
@@ -153,16 +152,6 @@ public class ArticleServiceTest extends IntegrationTest {
                 () -> assertThat(tags).hasSize(1),
                 () -> assertThat(tags.get(0).getName()).isEqualTo("SPRING")
         );
-    }
-
-    @Test
-    void 비회원은_게시글을_저장할_수_없다() {
-        ArticleRequest articleRequest = new ArticleRequest("질문합니다.", "내용입니다~!", Category.QUESTION.getValue(),
-                List.of("Spring"), false);
-
-        assertThatThrownBy(() -> articleService.create(new GuestMember(), articleRequest))
-                .isExactlyInstanceOf(NotMemberException.class)
-                .hasMessage("회원이 아니므로 권한이 없습니다.");
     }
 
     @Test
@@ -352,19 +341,6 @@ public class ArticleServiceTest extends IntegrationTest {
     }
 
     @Test
-    void 비회원이_게시글을_수정하면_예외가_발생한다() {
-        AppMember guestMember = new GuestMember();
-        ArticleRequest articleRequest = new ArticleRequest("질문합니다.", "내용입니다~!", Category.QUESTION.getValue(),
-                List.of("Spring"), false);
-        ArticleIdResponse savedArticle = articleService.create(new LoginMember(member.getId()), articleRequest);
-        ArticleUpdateRequest request = new ArticleUpdateRequest("제목 수정", "내용 수정합니다.", List.of("JAVA"));
-
-        assertThatThrownBy(() -> articleService.update(guestMember, request, savedArticle.getId()))
-                .isExactlyInstanceOf(NotMemberException.class)
-                .hasMessage("회원이 아니므로 권한이 없습니다.");
-    }
-
-    @Test
     void 회원이_게시글을_수정했을_때_해당_태그로_작성된_게시글이_없으면_태그도_삭제한다() {
         AppMember loginMember = new LoginMember(member.getId());
         ArticleRequest firstArticleRequest = new ArticleRequest("질문합니다.", "내용입니다~!", Category.QUESTION.getValue(),
@@ -433,18 +409,6 @@ public class ArticleServiceTest extends IntegrationTest {
     }
 
     @Test
-    void 비회원이_게시글을_삭제하면_예외가_발생한다() {
-        AppMember guestMember = new GuestMember();
-        ArticleRequest articleRequest = new ArticleRequest("질문합니다.", "내용입니다~!", Category.QUESTION.getValue(),
-                List.of("Spring"), false);
-        ArticleIdResponse savedArticle = articleService.create(new LoginMember(member.getId()), articleRequest);
-
-        assertThatThrownBy(() -> articleService.delete(guestMember, savedArticle.getId()))
-                .isExactlyInstanceOf(NotMemberException.class)
-                .hasMessage("회원이 아니므로 권한이 없습니다.");
-    }
-
-    @Test
     void 회원이_게시글을_삭제했을_때_해당_태그로_작성된_게시글이_없으면_태그도_삭제한다() {
         AppMember loginMember = new LoginMember(member.getId());
         ArticleRequest firstArticleRequest = new ArticleRequest("질문합니다.", "내용입니다~!", Category.QUESTION.getValue(),
@@ -484,7 +448,7 @@ public class ArticleServiceTest extends IntegrationTest {
 
         assertAll(
                 () -> assertThat(responses).hasSize(10),
-                () -> assertThat(response.getHasNext()).isEqualTo(true)
+                () -> assertThat(response.getHasNext()).isTrue()
         );
     }
 

--- a/backend/src/test/java/com/woowacourse/gongseek/article/domain/repository/ArticleTagRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/article/domain/repository/ArticleTagRepositoryTest.java
@@ -34,9 +34,6 @@ public class ArticleTagRepositoryTest {
     private MemberRepository memberRepository;
 
     @Autowired
-    private CommentRepository commentRepository;
-
-    @Autowired
     private TagRepository tagRepository;
 
     @BeforeEach

--- a/backend/src/test/java/com/woowacourse/gongseek/comment/application/CommentServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/comment/application/CommentServiceTest.java
@@ -11,7 +11,6 @@ import com.woowacourse.gongseek.article.exception.ArticleNotFoundException;
 import com.woowacourse.gongseek.auth.application.dto.GuestMember;
 import com.woowacourse.gongseek.auth.application.dto.LoginMember;
 import com.woowacourse.gongseek.auth.exception.NotAuthorException;
-import com.woowacourse.gongseek.auth.exception.NotMemberException;
 import com.woowacourse.gongseek.comment.application.dto.CommentRequest;
 import com.woowacourse.gongseek.comment.application.dto.CommentResponse;
 import com.woowacourse.gongseek.comment.application.dto.CommentUpdateRequest;
@@ -90,24 +89,6 @@ class CommentServiceTest extends IntegrationTest {
     }
 
     @Test
-    void 비회원은_기명_댓글을_생성할_수_없다() {
-        CommentRequest request = new CommentRequest(CONTENT, false);
-
-        assertThatThrownBy(() -> commentService.create(new GuestMember(), article.getId(), request))
-                .isExactlyInstanceOf(NotMemberException.class)
-                .hasMessage("회원이 아니므로 권한이 없습니다.");
-    }
-
-    @Test
-    void 비회원은_익명_댓글을_생성할_수_없다() {
-        CommentRequest request = new CommentRequest(CONTENT, true);
-
-        assertThatThrownBy(() -> commentService.create(new GuestMember(), article.getId(), request))
-                .isExactlyInstanceOf(NotMemberException.class)
-                .hasMessage("회원이 아니므로 권한이 없습니다.");
-    }
-
-    @Test
     void 회원이_존재하지_않는_경우_댓글을_생성할_수_없다() {
         CommentRequest request = new CommentRequest(CONTENT, false);
 
@@ -133,7 +114,7 @@ class CommentServiceTest extends IntegrationTest {
                 article.getId()).getComments();
 
         assertAll(
-                () -> assertThat(savedComments.size()).isEqualTo(1),
+                () -> assertThat(savedComments).hasSize(1),
                 () -> assertThat(savedComments.get(0))
                         .usingRecursiveComparison()
                         .ignoringFields("id", "createdAt", "updatedAt")
@@ -246,26 +227,6 @@ class CommentServiceTest extends IntegrationTest {
     }
 
     @Test
-    void 비회원은_기명_댓글을_수정할_수_없다() {
-        Comment comment = commentRepository.save(new Comment(CONTENT, member, article, false));
-        CommentUpdateRequest request = new CommentUpdateRequest(CONTENT);
-
-        assertThatThrownBy(() -> commentService.update(new GuestMember(), comment.getId(), request))
-                .isExactlyInstanceOf(NotMemberException.class)
-                .hasMessage("회원이 아니므로 권한이 없습니다.");
-    }
-
-    @Test
-    void 비회원은_익명_댓글을_수정할_수_없다() {
-        Comment comment = commentRepository.save(new Comment(CONTENT, member, article, true));
-        CommentUpdateRequest request = new CommentUpdateRequest(CONTENT);
-
-        assertThatThrownBy(() -> commentService.update(new GuestMember(), comment.getId(), request))
-                .isExactlyInstanceOf(NotMemberException.class)
-                .hasMessage("회원이 아니므로 권한이 없습니다.");
-    }
-
-    @Test
     void 댓글이_존재하지_않는_경우_수정할_수_없다() {
         assertThatThrownBy(
                 () -> commentService.update(new LoginMember(member.getId()), -1L,
@@ -316,24 +277,6 @@ class CommentServiceTest extends IntegrationTest {
         assertThatThrownBy(() -> commentService.delete(new LoginMember(newMember.getId()), comment.getId()))
                 .isExactlyInstanceOf(NotAuthorException.class)
                 .hasMessageContaining("작성자가 아니므로 권한이 없습니다.");
-    }
-
-    @Test
-    void 비회원인_경우_기명_댓글을_삭제할_수_없다() {
-        Comment comment = commentRepository.save(new Comment(CONTENT, member, article, false));
-
-        assertThatThrownBy(() -> commentService.delete(new GuestMember(), comment.getId()))
-                .isExactlyInstanceOf(NotMemberException.class)
-                .hasMessage("회원이 아니므로 권한이 없습니다.");
-    }
-
-    @Test
-    void 비회원인_경우_익명_댓글을_삭제할_수_없다() {
-        Comment comment = commentRepository.save(new Comment(CONTENT, member, article, true));
-
-        assertThatThrownBy(() -> commentService.delete(new GuestMember(), comment.getId()))
-                .isExactlyInstanceOf(NotMemberException.class)
-                .hasMessage("회원이 아니므로 권한이 없습니다.");
     }
 
     @Test

--- a/backend/src/test/java/com/woowacourse/gongseek/like/application/LikeServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/like/application/LikeServiceTest.java
@@ -8,9 +8,7 @@ import com.woowacourse.gongseek.article.domain.Article;
 import com.woowacourse.gongseek.article.domain.Category;
 import com.woowacourse.gongseek.article.domain.repository.ArticleRepository;
 import com.woowacourse.gongseek.article.exception.ArticleNotFoundException;
-import com.woowacourse.gongseek.auth.application.dto.GuestMember;
 import com.woowacourse.gongseek.auth.application.dto.LoginMember;
-import com.woowacourse.gongseek.auth.exception.NotMemberException;
 import com.woowacourse.gongseek.like.domain.repository.LikeRepository;
 import com.woowacourse.gongseek.member.domain.Member;
 import com.woowacourse.gongseek.member.domain.repository.MemberRepository;
@@ -48,16 +46,6 @@ class LikeServiceTest extends IntegrationTest {
     }
 
     @Test
-    void 비회원인_경우_게시글을_추천할_수_없다() {
-        Member member = memberRepository.save(new Member("judy", "jurlring", "avatarUrl"));
-        Article article = articleRepository.save(new Article("title", "content", Category.QUESTION, member, false));
-
-        assertThatThrownBy(() -> likeService.likeArticle(new GuestMember(), article.getId()))
-                .isExactlyInstanceOf(NotMemberException.class)
-                .hasMessage("회원이 아니므로 권한이 없습니다.");
-    }
-
-    @Test
     void 게시글이_존재하지_않은_경우_게시글을_추천할_수_없다() {
         Member member = memberRepository.save(new Member("judy", "jurlring", "avatarUrl"));
 
@@ -85,17 +73,7 @@ class LikeServiceTest extends IntegrationTest {
         likeService.unlikeArticle(appMember, article.getId());
         Article foundArticle = articleRepository.findById(article.getId()).get();
 
-        assertThat(foundArticle.getLikeCount()).isEqualTo(0);
-    }
-
-    @Test
-    void 비회원인_경우_게시글_추천을_취소할_수_없다() {
-        Member member = memberRepository.save(new Member("judy", "jurlring", "avatarUrl"));
-        Article article = articleRepository.save(new Article("title", "content", Category.QUESTION, member, false));
-
-        assertThatThrownBy(() -> likeService.unlikeArticle(new GuestMember(), article.getId()))
-                .isExactlyInstanceOf(NotMemberException.class)
-                .hasMessageContaining("권한이 없습니다.");
+        assertThat(foundArticle.getLikeCount()).isZero();
     }
 
     @Test


### PR DESCRIPTION
## 진행한 일
- HTTP METHOD가 POST, PUT, PATCH, DELETE 일 때 인터셉터에서 권한에 대한 예외를 발생하게 했습니다.
  이전에는 리소스를 생성, 수정, 삭제하는 서비스 메서드 가장 앞에서 비회원인지 검증하고 예외를 발생시키게 했었습니다. 이렇게 구현했던 이유는 권한이 없을 때 빠르게 예외를 발생시켜야 한다고 생각했기 때문이에요. 그런데 이렇게 구현할 것이라면 더 앞쪽인 인터셉터에서 권한을 확인해도 괜찮을 것이라고 생각돼요 :)
- 중복 로직 및 메서드 위치를 변경했습니다.
- 조회시 반환 값인 Response를 명시하도록 수정했습니다.
```
return checkGuest(article, appMember, voteRepository.existsByArticleId(article.getId()), 
                isLike(article, appMember)); // 이전
        return ArticleResponse.of(article, checkAuthor(article, appMember),
                voteRepository.existsByArticleId(article.getId()), isLike(article, appMember)); // 현재
```


Close #911 