### PR TITLE
도메인 event를 통해 의존성 분리 및 비동기 처리 개선

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongseek/article/application/ArticleService.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/article/application/ArticleService.java
@@ -6,6 +6,7 @@ import com.woowacourse.gongseek.article.application.dto.ArticleRequest;
 import com.woowacourse.gongseek.article.application.dto.ArticleResponse;
 import com.woowacourse.gongseek.article.application.dto.ArticleUpdateRequest;
 import com.woowacourse.gongseek.article.application.dto.ArticleUpdateResponse;
+import com.woowacourse.gongseek.article.application.dto.TempArticleEvent;
 import com.woowacourse.gongseek.article.domain.Article;
 import com.woowacourse.gongseek.article.domain.repository.ArticleRepository;
 import com.woowacourse.gongseek.article.domain.repository.ArticleTagRepository;
@@ -26,6 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -39,7 +41,7 @@ public class ArticleService {
     private final ArticleRepository articleRepository;
     private final ArticleTagRepository articleTagRepository;
     private final PagingArticleRepository pagingArticleRepository;
-    private final TempArticleService tempArticleService;
+    private final ApplicationEventPublisher eventPublisher;
     private final MemberRepository memberRepository;
     private final VoteRepository voteRepository;
     private final TagService tagService;
@@ -52,7 +54,9 @@ public class ArticleService {
         Article article = articleRepository.save(articleRequest.toArticle(member));
         article.addTag(foundTags);
 
-        tempArticleService.delete(articleRequest.getTempArticleId(), appMember);
+        if (articleRequest.getTempArticleId() != null) {
+            eventPublisher.publishEvent(new TempArticleEvent(articleRequest.getTempArticleId()));
+        }
         return new ArticleIdResponse(article);
     }
 

--- a/backend/src/main/java/com/woowacourse/gongseek/article/application/TempArticleEventHandler.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/article/application/TempArticleEventHandler.java
@@ -1,0 +1,20 @@
+package com.woowacourse.gongseek.article.application;
+
+import com.woowacourse.gongseek.article.application.dto.TempArticleEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+@Component
+public class TempArticleEventHandler {
+
+    private final TempArticleEventService tempArticleEventService;
+
+    @Async
+    @TransactionalEventListener
+    public void deleteTempArticle(TempArticleEvent event) {
+        tempArticleEventService.delete(event.getTempArticleId());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/gongseek/article/application/TempArticleEventService.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/article/application/TempArticleEventService.java
@@ -1,0 +1,17 @@
+package com.woowacourse.gongseek.article.application;
+
+import com.woowacourse.gongseek.article.domain.repository.TempArticleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class TempArticleEventService {
+    private final TempArticleRepository tempArticleRepository;
+
+    public void delete(Long id) {
+        tempArticleRepository.deleteById(id);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/gongseek/article/application/dto/TempArticleEvent.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/article/application/dto/TempArticleEvent.java
@@ -1,0 +1,10 @@
+package com.woowacourse.gongseek.article.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class TempArticleEvent {
+    private Long tempArticleId;
+}

--- a/backend/src/main/java/com/woowacourse/gongseek/article/exception/TempArticleNotFoundException.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/article/exception/TempArticleNotFoundException.java
@@ -1,7 +1,10 @@
 package com.woowacourse.gongseek.article.exception;
 
 import com.woowacourse.gongseek.common.exception.NotFoundException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TempArticleNotFoundException extends NotFoundException {
 
     public TempArticleNotFoundException(long tempArticleId) {

--- a/backend/src/main/java/com/woowacourse/gongseek/common/exception/CustomAsyncExceptionHandler.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/common/exception/CustomAsyncExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.woowacourse.gongseek.common.exception;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+
+@Slf4j
+public class CustomAsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
+
+    @Override
+    public void handleUncaughtException(Throwable throwable, Method method, Object... params) {
+        log.warn("비동기 처리에서 예외가 발생했습니다."
+                + "예외 메세지 : " + throwable.getMessage()
+                + "메서드 이름 : " + method.getName()
+                + "파라미터 : " + Arrays.toString(params));
+    }
+}

--- a/backend/src/main/java/com/woowacourse/gongseek/config/AsyncConfig.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/config/AsyncConfig.java
@@ -1,9 +1,17 @@
 package com.woowacourse.gongseek.config;
 
+import com.woowacourse.gongseek.common.exception.CustomAsyncExceptionHandler;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @Configuration
 @EnableAsync
-public class AsyncConfig{
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new CustomAsyncExceptionHandler();
+    }
 }

--- a/backend/src/main/java/com/woowacourse/gongseek/config/AsyncConfig.java
+++ b/backend/src/main/java/com/woowacourse/gongseek/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.woowacourse.gongseek.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig{
+}

--- a/backend/src/test/java/com/woowacourse/gongseek/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/acceptance/AcceptanceTest.java
@@ -1,12 +1,10 @@
 package com.woowacourse.gongseek.acceptance;
 
-import com.woowacourse.gongseek.support.DatabaseCleaner;
 import com.woowacourse.gongseek.support.RedisContainerTest;
 import com.woowacourse.gongseek.support.RollbackExtension;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;

--- a/backend/src/test/java/com/woowacourse/gongseek/acceptance/ArticleAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/acceptance/ArticleAcceptanceTest.java
@@ -63,9 +63,10 @@ public class ArticleAcceptanceTest extends AcceptanceTest {
             "익명",
             "https://raw.githubusercontent.com/woowacourse-teams/2022-gong-seek/develop/frontend/src/assets/gongseek.png"
     );
+    private static final int ASYNC_TIME_WAIT = 2000;
 
     @Test
-    void 임시_게시글을_만들었을때_게시글을_저장하면_임시_게시글은_삭제된다() {
+    void 임시_게시글을_만들었을때_게시글을_저장하면_임시_게시글은_삭제된다() throws InterruptedException {
         // given
         AccessTokenResponse tokenResponse = 로그인을_한다(기론);
 
@@ -79,6 +80,7 @@ public class ArticleAcceptanceTest extends AcceptanceTest {
                 new ArticleRequest("커스텀예외를 처리하는 방법", "내용", Category.DISCUSSION.getValue(), List.of("JAVA", "SPRING"),
                         false, tmpArticleId));
         ArticleIdResponse articleIdResponse = response.as(ArticleIdResponse.class);
+        Thread.sleep(ASYNC_TIME_WAIT);
         TempArticleNotFoundException exception = 임시_게시글_단건_조회한다(tokenResponse, tmpArticleId)
                 .as(TempArticleNotFoundException.class);
 

--- a/backend/src/test/java/com/woowacourse/gongseek/article/application/ArticleServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/article/application/ArticleServiceTest.java
@@ -11,12 +11,7 @@ import com.woowacourse.gongseek.article.application.dto.ArticleResponse;
 import com.woowacourse.gongseek.article.application.dto.ArticleUpdateRequest;
 import com.woowacourse.gongseek.article.domain.Article;
 import com.woowacourse.gongseek.article.domain.Category;
-import com.woowacourse.gongseek.article.domain.Content;
-import com.woowacourse.gongseek.article.domain.TempArticle;
-import com.woowacourse.gongseek.article.domain.TempTags;
-import com.woowacourse.gongseek.article.domain.Title;
 import com.woowacourse.gongseek.article.domain.repository.ArticleRepository;
-import com.woowacourse.gongseek.article.domain.repository.TempArticleRepository;
 import com.woowacourse.gongseek.article.domain.repository.dto.ArticlePreviewDto;
 import com.woowacourse.gongseek.article.exception.ArticleNotFoundException;
 import com.woowacourse.gongseek.article.exception.DuplicateTagException;
@@ -49,7 +44,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.test.context.transaction.TestTransaction;
 import org.springframework.transaction.annotation.Transactional;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -58,20 +52,25 @@ public class ArticleServiceTest extends IntegrationTest {
     private final Member member = new Member("slo", "hanull", "avatar.com");
     @Autowired
     private ArticleService articleService;
+
     @Autowired
     private ArticleRepository articleRepository;
-    @Autowired
-    private TempArticleRepository tempArticleRepository;
+
     @Autowired
     private MemberRepository memberRepository;
+
     @Autowired
     private VoteService voteService;
+
     @Autowired
     private VoteItemRepository voteItemRepository;
+
     @Autowired
     private VoteHistoryRepository voteHistoryRepository;
+
     @Autowired
     private TagRepository tagRepository;
+
     @Autowired
     private LikeService likeService;
 
@@ -92,39 +91,6 @@ public class ArticleServiceTest extends IntegrationTest {
         assertAll(
                 () -> assertThat(articleIdResponse.getId()).isNotNull(),
                 () -> assertThat(foundArticle.getArticleTags().getValue()).hasSize(1)
-        );
-    }
-
-    @Transactional
-    @Test
-    void 임시_게시글을_만들었을때_게시글을_저장하면_임시_게시글은_삭제된다() {
-
-        // given
-        final TempArticle tempArticle = TempArticle.builder()
-                .title(new Title("title"))
-                .content(new Content("content"))
-                .category(Category.QUESTION)
-                .member(member)
-                .tempTags(new TempTags(List.of("spring")))
-                .isAnonymous(false)
-                .build();
-        TempArticle savedTempArticle = tempArticleRepository.save(tempArticle);
-        ArticleRequest articleRequest = new ArticleRequest("질문합니다.", "내용입니다~!", Category.QUESTION.getValue(),
-                List.of("Spring"), false, savedTempArticle.getId());
-
-        // when
-        ArticleIdResponse articleIdResponse = articleService.create(new LoginMember(member.getId()), articleRequest);
-        TestTransaction.flagForCommit();
-        TestTransaction.end();
-
-        // then
-        TestTransaction.start();
-        Article foundArticle = articleRepository.findById(articleIdResponse.getId()).get();
-
-        assertAll(
-                () -> assertThat(articleIdResponse.getId()).isNotNull(),
-                () -> assertThat(foundArticle.getArticleTags().getValue()).hasSize(1),
-                () -> assertThat(tempArticleRepository.findByIdWithMember(savedTempArticle.getId())).isEmpty()
         );
     }
 

--- a/backend/src/test/java/com/woowacourse/gongseek/article/application/TempArticleServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/article/application/TempArticleServiceTest.java
@@ -29,6 +29,7 @@ import org.springframework.test.context.transaction.TestTransaction;
 import org.springframework.transaction.annotation.Transactional;
 
 class TempArticleServiceTest extends IntegrationTest {
+    private static final int ASYNC_TIME_WAIT = 2000;
 
     @Autowired
     private TempArticleService tempArticleService;
@@ -148,7 +149,7 @@ class TempArticleServiceTest extends IntegrationTest {
 
     @Transactional
     @Test
-    void 임시_게시글을_만들었을때_게시글을_저장하면_임시_게시글은_삭제된다() {
+    void 임시_게시글을_만들었을때_게시글을_저장하면_임시_게시글은_삭제된다() throws InterruptedException {
 
         // given
         final TempArticle tempArticle = TempArticle.builder()
@@ -168,6 +169,7 @@ class TempArticleServiceTest extends IntegrationTest {
         TestTransaction.flagForCommit();
         TestTransaction.end();
 
+        Thread.sleep(ASYNC_TIME_WAIT);
         // then
         ArticleResponse foundArticle = articleService.getOne(new LoginMember(member.getId()),
                 articleIdResponse.getId());

--- a/backend/src/test/java/com/woowacourse/gongseek/article/application/TempArticleServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongseek/article/application/TempArticleServiceTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.gongseek.article.application.dto.ArticleIdResponse;
 import com.woowacourse.gongseek.article.application.dto.ArticleRequest;
+import com.woowacourse.gongseek.article.application.dto.ArticleResponse;
 import com.woowacourse.gongseek.article.application.dto.TempArticleDetailResponse;
 import com.woowacourse.gongseek.article.application.dto.TempArticleIdResponse;
 import com.woowacourse.gongseek.article.application.dto.TempArticlesResponse;
@@ -23,6 +25,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.transaction.TestTransaction;
 import org.springframework.transaction.annotation.Transactional;
 
 class TempArticleServiceTest extends IntegrationTest {
@@ -145,20 +148,34 @@ class TempArticleServiceTest extends IntegrationTest {
 
     @Transactional
     @Test
-    void 게시글을_생성하면_임시_게시글은_삭제된다() {
-        final TempArticle tempArticle = tempArticleRepository.save(TempArticle.builder()
+    void 임시_게시글을_만들었을때_게시글을_저장하면_임시_게시글은_삭제된다() {
+
+        // given
+        final TempArticle tempArticle = TempArticle.builder()
                 .title(new Title("title"))
                 .content(new Content("content"))
                 .category(Category.QUESTION)
                 .member(member)
                 .tempTags(new TempTags(List.of("spring")))
                 .isAnonymous(false)
-                .build());
-        final ArticleRequest articleRequest = new ArticleRequest("질문합니다.", "내용입니다~!", Category.QUESTION.getValue(),
-                List.of("Spring"), true, tempArticle.getId());
+                .build();
+        TempArticle savedTempArticle = tempArticleRepository.save(tempArticle);
+        ArticleRequest articleRequest = new ArticleRequest("질문합니다.", "내용입니다~!", Category.QUESTION.getValue(),
+                List.of("Spring"), false, savedTempArticle.getId());
 
-        articleService.create(new LoginMember(member.getId()), articleRequest);
+        // when
+        ArticleIdResponse articleIdResponse = articleService.create(new LoginMember(member.getId()), articleRequest);
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
 
-        assertThat(tempArticleRepository.existsById(tempArticle.getId())).isFalse();
+        // then
+        ArticleResponse foundArticle = articleService.getOne(new LoginMember(member.getId()),
+                articleIdResponse.getId());
+
+        assertAll(
+                () -> assertThat(articleIdResponse.getId()).isNotNull(),
+                () -> assertThat(foundArticle.getTag()).hasSize(1),
+                () -> assertThat(tempArticleRepository.existsById(savedTempArticle.getId())).isFalse()
+        );
     }
 }


### PR DESCRIPTION
### 한일
이슈 #913에 적어놨습니다. 

간략히 설명드리면 게시글을 생성하면 임시 저장된 게시글이 삭제될때까지 기다렸다가 생성이 되는데 이것을 비동기로 처리해봤습니다. 그리고 event를 통해서 의존성도 분리해봤어요. 

### 추가 의견 궁금합니다
지금 비동기 예외처리로 비동기에서 예외가 발생하면 log에 warn 레벨로 예외가 발생했다고 찍어놨는데 
이 예외가 발생한 tempArticleId들만 따로 테이블에 저장해서 나중에 스케줄러로 처리하는 것도 좋은 것 같은데 어떠신가요?
(임시 게시글 삭제 실패했던 id들만 따로 저장해줬다가 스케줄러로 처리)


Close #913 